### PR TITLE
Pagination

### DIFF
--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -195,8 +195,8 @@ instance FromJSON RPCReqParams where
         (GetRawTransactionsByTxIDs <$> o .: "gtRTxHashes") <|>
         (GetOutputsByAddress <$> o .: "gaAddrOutputs" <*> o .:? "gaPageSize" <*> o .:? "gaNominalTxIndex")  <|>
         (GetOutputsByAddresses <$> o .: "gasAddrOutputs" <*> o .:? "gasPageSize" <*> o .:? "gasNominalTxIndex") <|>
-        (GetOutputsByScriptHash <$> o .: "gaScriptHashOutputs" <*> o .:? "gaScriptHashPageSize" <*> o .: "gaScriptHashNominalTxIndex") <|>
-        (GetOutputsByScriptHashes <$> o .: "gasScriptHashOutputs" <*> o .:? "gasScriptHashPageSize" <*> o .: "gasScriptHashNominalTxIndex") <|>
+        (GetOutputsByScriptHash <$> o .: "gaScriptHashOutputs" <*> o .:? "gaScriptHashPageSize" <*> o .:? "gaScriptHashNominalTxIndex") <|>
+        (GetOutputsByScriptHashes <$> o .: "gasScriptHashOutputs" <*> o .:? "gasScriptHashPageSize" <*> o .:? "gasScriptHashNominalTxIndex") <|>
         (GetMerkleBranchByTxID <$> o .: "gmbMerkleBranch") <|>
         (GetAllegoryNameBranch <$> o .: "gaName" <*> o .: "gaIsProducer") <|>
         (RelayTx . BL.toStrict . GZ.decompress . B64L.decodeLenient . BL.fromStrict . T.encodeUtf8 <$> o .: "rTx") <|>

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -148,8 +148,7 @@ data RPCReqParams
     | GetOutputsByAddress
           { gaAddrOutputs :: String
           , gaPageSize :: Maybe Int32
-          , gaLastBlockHeight :: Maybe Int
-          , gaLastTxInd :: Maybe Int
+          , gaNominalTxIndex :: Maybe Int64
           }
     | GetOutputsByAddresses
           { gasAddrOutputs :: [String]
@@ -188,8 +187,7 @@ instance FromJSON RPCReqParams where
         (GetTransactionsByTxIDs <$> o .: "gtTxHashes") <|>
         (GetRawTransactionByTxID <$> o .: "gtRTxHash") <|>
         (GetRawTransactionsByTxIDs <$> o .: "gtRTxHashes") <|>
-        (GetOutputsByAddress <$> o .: "gaAddrOutputs" <*> o .:? "gaPageSize" <*> o .:? "gaLastBlockHeight" <*>
-        o .:? "gaLastTxIndex") <|>
+        (GetOutputsByAddress <$> o .: "gaAddrOutputs" <*> o .:? "gaPageSize" <*> o .:? "gaNominalTxIndex")  <|>
         (GetOutputsByAddresses <$> o .: "gasAddrOutputs") <|>
         (GetOutputsByScriptHash <$> o .: "gaScriptHashOutputs") <|>
         (GetOutputsByScriptHashes <$> o .: "gasScriptHashOutputs") <|>
@@ -307,6 +305,7 @@ data AddressOutputs =
         { aoAddress :: String
         , aoOutput :: OutPoint'
         , aoBlockInfo :: BlockInfo'
+        , aoNominalTxIndex :: Int64
         , aoIsBlockConfirmed :: Bool
         , aoIsOutputSpent :: Bool
         , aoIsTypeReceive :: Bool
@@ -324,6 +323,7 @@ data ScriptOutputs =
         { scScriptHash :: String
         , scOutput :: OutPoint'
         , scBlockInfo :: BlockInfo'
+        , scNominalTxIndex :: Int64
         , scIsBlockConfirmed :: Bool
         , scIsOutputSpent :: Bool
         , scIsTypeReceive :: Bool
@@ -339,15 +339,15 @@ instance ToJSON ScriptOutputs where
 data OutPoint' =
     OutPoint'
         { opTxHash :: String
-        , opIndex :: Int
+        , opIndex :: Int32
         }
     deriving (Show, Generic, Hashable, Eq, Serialise, FromJSON, ToJSON)
 
 data BlockInfo' =
     BlockInfo'
         { binfBlockHash :: String
-        , binfTxIndex :: Int
-        , binfBlockHeight :: Int
+        , binfTxIndex :: Int32
+        , binfBlockHeight :: Int32
         }
     deriving (Show, Generic, Hashable, Eq, Serialise, ToJSON)
 
@@ -421,6 +421,7 @@ addressToScriptOutputs AddressOutputs {..} =
         { scScriptHash = aoAddress
         , scOutput = aoOutput
         , scBlockInfo = aoBlockInfo
+        , scNominalTxIndex = aoNominalTxIndex
         , scIsBlockConfirmed = aoIsBlockConfirmed
         , scIsOutputSpent = aoIsOutputSpent
         , scIsTypeReceive = aoIsTypeReceive

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -147,6 +147,9 @@ data RPCReqParams
           }
     | GetOutputsByAddress
           { gaAddrOutputs :: String
+          , gaPageSize :: Maybe Int32
+          , gaLastBlockHeight :: Maybe Int
+          , gaLastTxInd :: Maybe Int
           }
     | GetOutputsByAddresses
           { gasAddrOutputs :: [String]
@@ -185,7 +188,8 @@ instance FromJSON RPCReqParams where
         (GetTransactionsByTxIDs <$> o .: "gtTxHashes") <|>
         (GetRawTransactionByTxID <$> o .: "gtRTxHash") <|>
         (GetRawTransactionsByTxIDs <$> o .: "gtRTxHashes") <|>
-        (GetOutputsByAddress <$> o .: "gaAddrOutputs") <|>
+        (GetOutputsByAddress <$> o .: "gaAddrOutputs" <*> o .:? "gaPageSize" <*> o .:? "gaLastBlockHeight" <*>
+        o .:? "gaLastTxIndex") <|>
         (GetOutputsByAddresses <$> o .: "gasAddrOutputs") <|>
         (GetOutputsByScriptHash <$> o .: "gaScriptHashOutputs") <|>
         (GetOutputsByScriptHashes <$> o .: "gasScriptHashOutputs") <|>

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -152,12 +152,18 @@ data RPCReqParams
           }
     | GetOutputsByAddresses
           { gasAddrOutputs :: [String]
+          , gasPageSize :: Maybe Int32
+          , gasNominalTxIndex :: Maybe Int64
           }
     | GetOutputsByScriptHash
           { gaScriptHashOutputs :: String
+          , gaScriptHashPageSize :: Maybe Int32
+          , gaScriptHashNominalTxIndex :: Maybe Int64
           }
     | GetOutputsByScriptHashes
           { gasScriptHashOutputs :: [String]
+          , gasScriptHashPageSize :: Maybe Int32
+          , gasScriptHashNominalTxIndex :: Maybe Int64
           }
     | GetMerkleBranchByTxID
           { gmbMerkleBranch :: String
@@ -188,9 +194,9 @@ instance FromJSON RPCReqParams where
         (GetRawTransactionByTxID <$> o .: "gtRTxHash") <|>
         (GetRawTransactionsByTxIDs <$> o .: "gtRTxHashes") <|>
         (GetOutputsByAddress <$> o .: "gaAddrOutputs" <*> o .:? "gaPageSize" <*> o .:? "gaNominalTxIndex")  <|>
-        (GetOutputsByAddresses <$> o .: "gasAddrOutputs") <|>
-        (GetOutputsByScriptHash <$> o .: "gaScriptHashOutputs") <|>
-        (GetOutputsByScriptHashes <$> o .: "gasScriptHashOutputs") <|>
+        (GetOutputsByAddresses <$> o .: "gasAddrOutputs" <*> o .:? "gasPageSize" <*> o .:? "gasNominalTxIndex") <|>
+        (GetOutputsByScriptHash <$> o .: "gaScriptHashOutputs" <*> o .:? "gaScriptHashPageSize" <*> o .: "gaScriptHashNominalTxIndex") <|>
+        (GetOutputsByScriptHashes <$> o .: "gasScriptHashOutputs" <*> o .:? "gasScriptHashPageSize" <*> o .: "gasScriptHashNominalTxIndex") <|>
         (GetMerkleBranchByTxID <$> o .: "gmbMerkleBranch") <|>
         (GetAllegoryNameBranch <$> o .: "gaName" <*> o .: "gaIsProducer") <|>
         (RelayTx . BL.toStrict . GZ.decompress . B64L.decodeLenient . BL.fromStrict . T.encodeUtf8 <$> o .: "rTx") <|>

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -360,18 +360,21 @@ commitAddressOutputs ::
 commitAddressOutputs conn addr typeRecv otherAddr output blockInfo prevOutpoint value = do
     lg <- getLogger
     let str =
-            "insert INTO xoken.address_outputs ( address, is_type_receive,other_address, output, block_info, prev_outpoint, value, is_block_confirmed, is_output_spent ) values (?, ?, ?, ?, ?, ? ,? ,? ,?)"
+            "insert INTO xoken.address_outputs ( address, is_type_receive,other_address, output, blockhash, block_height, txindex, prev_outpoint, value, is_block_confirmed, is_output_spent ) values (?, ?, ?, ?, ?, ? ,? ,? ,?, ?, ?)"
+        ((blockHash, blockHeight), txIndex) = blockInfo
         qstr =
             str :: Q.QueryString Q.W ( Text
                                      , Bool
                                      , Maybe Text
                                      , (Text, Int32)
-                                     , ((Text, Int32), Int32)
+                                     , Text
+                                     , Int32
+                                     , Int32
                                      , (Text, Int32)
                                      , Int64
                                      , Bool
                                      , Bool) ()
-        par = Q.defQueryParams Q.One (addr, typeRecv, otherAddr, output, blockInfo, prevOutpoint, value, False, False)
+        par = Q.defQueryParams Q.One (addr, typeRecv, otherAddr, output, blockHash, blockHeight, txIndex, prevOutpoint, value, False, False)
     res1 <- liftIO $ try $ Q.runClient conn (Q.write (qstr) par)
     case res1 of
         Right () -> return ()

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -279,7 +279,7 @@ xGetOutputsAddresses net addresses pgSize mbNomTxInd = do
                                                           , (DT.Text, Int32)
                                                           , Int64)
         p = Q.defQueryParams Q.One (Data.List.map (DT.pack) addresses, nominalTxIndex)
-    res <- LE.try $ Q.runClient conn (Q.query qstr p)
+    res <- LE.try $ Q.runClient conn (Q.query qstr (p {pageSize = pgSize}))
     case res of
         Right iop -> do
             if length iop == 0

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -270,62 +270,6 @@ xGetOutputsAddresses net addresses pgSize mbNomTxInd = do
                                          ao2n = aoNominalTxIndex ao2
     return $ (L.take pageSize . sortBy sortAddressOutputs . concat $ listOfAddresses)
 
-{-
-xGetOutputsAddresses :: (HasXokenNodeEnv env m, HasLogger m, MonadIO m)
-                     => Network
-                     -> [String]
-                     -> Maybe Int32
-                     -> Maybe Int64
-                     -> m ([AddressOutputs])
-xGetOutputsAddresses net addresses pgSize mbNomTxInd = do
-    dbe <- getDB
-    lg <- getLogger
-    let conn = keyValDB (dbe)
-        nominalTxIndex = case mbNomTxInd of
-            (Just n) -> n
-            Nothing -> maxBound
-        str =
-            "SELECT address,output,block_info,nominal_tx_index,is_block_confirmed,is_output_spent,is_type_receive,other_address,prev_outpoint,value from xoken.address_outputs where address in ? and nominal_tx_index < ?"
-        qstr =
-            str :: Q.QueryString Q.R ([DT.Text], Int64) ( DT.Text
-                                                          , (DT.Text, Int32)
-                                                          , ((DT.Text, Int32), Int32)
-                                                          , Int64
-                                                          , Bool
-                                                          , Bool
-                                                          , Bool
-                                                          , Maybe DT.Text
-                                                          , (DT.Text, Int32)
-                                                          , Int64)
-        p = Q.defQueryParams Q.One (Data.List.map (DT.pack) addresses, nominalTxIndex)
-    res <- LE.try $ Q.runClient conn (Q.query qstr (p {pageSize = pgSize}))
-    case res of
-        Right iop -> do
-            if length iop == 0
-                then return []
-                else do
-                    return $
-                        Data.List.map
-                            (\(addr, (txhs, ind), ((bhash, blkht), txind), nomTxInd, fconf, fospent, freceive, oaddr, (ptxhs, pind), val) ->
-                                 AddressOutputs
-                                     (DT.unpack addr)
-                                     (OutPoint' (DT.unpack txhs) (fromIntegral ind))
-                                     (BlockInfo' (DT.unpack bhash) (fromIntegral txind) (fromIntegral blkht))
-                                     nomTxInd
-                                     fconf
-                                     fospent
-                                     freceive
-                                     (if isJust oaddr
-                                          then DT.unpack $ fromJust oaddr
-                                          else "")
-                                     (OutPoint' (DT.unpack ptxhs) (fromIntegral pind))
-                                     val)
-                            iop
-        Left (e :: SomeException) -> do
-            err lg $ LG.msg $ "Error: xGetOutputsAddresses: " ++ show e
-            throw KeyValueDBLookupException
-
--}
 
 xGetMerkleBranch :: (HasXokenNodeEnv env m, HasLogger m, MonadIO m) => Network -> String -> m ([MerkleBranchNode'])
 xGetMerkleBranch net txid = do

--- a/schema.cql
+++ b/schema.cql
@@ -3,19 +3,19 @@ CREATE KEYSPACE xoken WITH replication = {'class': 'SimpleStrategy', 'replicatio
 CREATE TABLE xoken.misc_store (
     key text PRIMARY KEY,
     value frozen<tuple<boolean, int, bigint, text>>
-) 
+); 
 
 CREATE TABLE xoken.transactions (
     tx_id text PRIMARY KEY,
     block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
     tx_serialized blob
-) 
+);
 
 CREATE TABLE xoken.blocks_by_hash (
     block_hash text PRIMARY KEY,
     block_header text,
     block_height int
-) 
+); 
 
 CREATE TABLE xoken.ep_address_outputs (
     epoch boolean,
@@ -27,36 +27,38 @@ CREATE TABLE xoken.ep_address_outputs (
     prev_outpoint frozen<tuple<text, int>>,
     value bigint,
     PRIMARY KEY (epoch, address, output)
-) 
+);
 
 CREATE TABLE xoken.address_outputs (
     address text,
     output frozen<tuple<text, int>>,
-    block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
+    blockhash text,
+    block_height int,
+    txindex int,
     is_block_confirmed boolean,
     is_output_spent boolean,
     is_type_receive boolean,
     other_address text,
     prev_outpoint frozen<tuple<text, int>>,
     value bigint,
-    PRIMARY KEY (address, output)
-) 
+    PRIMARY KEY (address, block_height, txindex, output)
+) WITH CLUSTERING ORDER BY (block_height DESC, txindex DESC); 
 
 CREATE TABLE xoken.txidmap (
     txid text PRIMARY KEY,
     blockhash text,
     txindex int
-) 
+); 
 
 CREATE TABLE xoken.blocks_by_height (
     block_height int PRIMARY KEY,
     block_hash text,
     block_header text
-) 
+); 
 
 CREATE TABLE xoken.ep_transactions (
     epoch boolean,
     tx_id text,
     tx_serialized blob,
     PRIMARY KEY (epoch, tx_id)
-) 
+); 

--- a/schema.cql
+++ b/schema.cql
@@ -32,17 +32,16 @@ CREATE TABLE xoken.ep_address_outputs (
 CREATE TABLE xoken.address_outputs (
     address text,
     output frozen<tuple<text, int>>,
-    blockhash text,
-    block_height int,
-    txindex int,
+    block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
+    nominal_tx_index bigint,
     is_block_confirmed boolean,
     is_output_spent boolean,
     is_type_receive boolean,
     other_address text,
     prev_outpoint frozen<tuple<text, int>>,
     value bigint,
-    PRIMARY KEY (address, block_height, txindex, output)
-) WITH CLUSTERING ORDER BY (block_height DESC, txindex DESC); 
+    PRIMARY KEY (address, nominal_tx_index, output)
+) WITH CLUSTERING ORDER BY (nominal_tx_index DESC); 
 
 CREATE TABLE xoken.txidmap (
     txid text PRIMARY KEY,


### PR DESCRIPTION
### Added Sorted Pagination:
**Changes:**

- Data.hs:
  - GetOutputsByAddress, GetOutputsByAddresses, GetOutputsByScriptHash, GetOutputsByScriptHashes all now have pageSize (Maybe Int32) and nominalTxIndex (Maybe Int64)
  - Changed RPCReqParams' FromJSON instance to accomodate data change
  - Added nominalTxIndex fields to AddressOutputs and ScriptOutputs
  - Changed some Ints to Int32s

- BlockSync.hs
  - commitAddress now add nominalTxIndex which is equal to blockHeight*1000000000+txIndex

- XokenService.hs
  - xGetOutputsAddress now uses page size and nominal tx index for sorted pagination
  - xGetOutputsAddresses rather than using IN clause in CQL query, now concurrently calls xGetOutputsAddress for all addresses and then sorts them

- schema.cql
  - added nominalTxIndex to address_outputs table
  - primary key now includes nominalTxIndex as clustering key
  - address_outputs is ordered by nominalTxIndex
 