### PR TITLE
Fix API error handling

### DIFF
--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -523,7 +523,7 @@ goGetResource msg net = do
                 _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
         "ADDR->[OUTPUT]" -> do
             case rqParams msg of
-                Just (GetOutputsByAddress addr psize nominalTxIndex) -> do
+                Just (GetOutputsByAddress addr psize@(Just psize') nominalTxIndex@(Just nominalTxIndex')) -> do
                     ops <-
                         case convertToScriptHash net addr of
                             Just o -> xGetOutputsAddress net o psize nominalTxIndex
@@ -533,7 +533,7 @@ goGetResource msg net = do
                 _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
         "[ADDR]->[OUTPUT]" -> do
             case rqParams msg of
-                Just (GetOutputsByAddresses addrs pgSize nomTxInd) -> do
+                Just (GetOutputsByAddresses addrs pgSize@(Just pgSize') nomTxInd@(Just nomTxInd')) -> do
                     let (shs, shMap) =
                             L.foldl'
                                 (\(arr, m) x ->

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -489,7 +489,7 @@ goGetResource msg net = do
                     tx <- xGetTxHash net (hs)
                     case tx of
                         Just t -> return $ RPCResponse 200 Nothing $ Just $ RespRawTransactionByTxID t
-                        Nothing -> return $ RPCResponse 404 (Just INVALID_REQUEST) Nothing
+                        Nothing -> return $ RPCResponse 200 Nothing Nothing
                 _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
         "TXID->TX" -> do
             case rqParams msg of
@@ -503,7 +503,7 @@ goGetResource msg net = do
                                     RPCResponse 200 Nothing $
                                     Just $ RespTransactionByTxID (TxRecord txId txBlockInfo rt)
                                 Left err -> return $ RPCResponse 400 (Just INTERNAL_ERROR) Nothing
-                        Nothing -> return $ RPCResponse 404 (Just INVALID_REQUEST) Nothing
+                        Nothing -> return $ RPCResponse 200 Nothing Nothing 
                 _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
         "[TXID]->[RAWTX]" -> do
             case rqParams msg of

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -523,7 +523,7 @@ goGetResource msg net = do
                 _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
         "ADDR->[OUTPUT]" -> do
             case rqParams msg of
-                Just (GetOutputsByAddress addr psize@(Just psize') nominalTxIndex@(Just nominalTxIndex')) -> do
+                Just (GetOutputsByAddress addr psize nominalTxIndex) -> do
                     ops <-
                         case convertToScriptHash net addr of
                             Just o -> xGetOutputsAddress net o psize nominalTxIndex
@@ -533,7 +533,7 @@ goGetResource msg net = do
                 _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
         "[ADDR]->[OUTPUT]" -> do
             case rqParams msg of
-                Just (GetOutputsByAddresses addrs pgSize@(Just pgSize') nomTxInd@(Just nomTxInd')) -> do
+                Just (GetOutputsByAddresses addrs pgSize nomTxInd) -> do
                     let (shs, shMap) =
                             L.foldl'
                                 (\(arr, m) x ->


### PR DESCRIPTION
TXID->RAWTX and TXID->TX would respond with INVALID_REQUEST if no Tx were to match given TXID. This was fixed, for them to now respond with an empty/null result in that case.