### PR TITLE
173463602 get chain info

### DIFF
--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -318,7 +318,18 @@ data ChainInfo =
         , ciHeaders :: Int32
         , ciBlocks :: Int32
         , ciBestBlockHash :: String
-        } deriving (Generic, Show, Hashable, Eq, Serialise, ToJSON)
+        } deriving (Generic, Show, Hashable, Eq, Serialise)
+
+instance ToJSON ChainInfo where
+    toJSON (ChainInfo ch cw diff hdr blk hs) =
+        object
+            [ "chain" .= ch
+            , "chainwork" .= cw
+            , "difficulty" .= diff
+            , "headers" .= hdr
+            , "blocks" .= blk
+            , "bestBlockHash" .= hs
+            ]
 
 data BlockRecord =
     BlockRecord

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -139,6 +139,9 @@ data RPCReqParams
     | GetBlocksByHashes
           { gbBlockHashes :: [String]
           }
+    | GetChainInfo
+          { gcChainInfo :: String
+          }
     | GetTransactionByTxID
           { gtTxHash :: String
           }
@@ -187,6 +190,8 @@ data RPCReqParams
           , gpsaOutputOwner :: String
           , gpsaOutputChange :: String
           }
+    
+    
     deriving (Generic, Show, Hashable, Eq, Serialise, ToJSON)
 
 instance FromJSON RPCReqParams where
@@ -195,6 +200,7 @@ instance FromJSON RPCReqParams where
         (GetBlocksByHeight <$> o .: "gbHeights") <|>
         (GetBlockByHash <$> o .: "gbBlockHash") <|>
         (GetBlocksByHashes <$> o .: "gbBlockHashes") <|>
+        (GetChainInfo <$> o .: "gcChainInfo") <|>
         (GetTransactionByTxID <$> o .: "gtTxHash") <|>
         (GetTransactionsByTxIDs <$> o .: "gtTxHashes") <|>
         (GetRawTransactionByTxID <$> o .: "gtRTxHash") <|>
@@ -226,6 +232,9 @@ data RPCResponseBody
           }
     | RespBlocksByHashes
           { blocks :: [BlockRecord]
+          }
+    | RespChainInfo
+          { chainwork :: String
           }
     | RespTransactionByTxID
           { tx :: TxRecord
@@ -271,6 +280,7 @@ instance ToJSON RPCResponseBody where
     toJSON (RespBlocksByHeight bs) = object ["blocks" .= bs]
     toJSON (RespBlockByHash b) = object ["block" .= b]
     toJSON (RespBlocksByHashes bs) = object ["blocks" .= bs]
+    toJSON (RespChainInfo cw) = object ["chainwork" .= cw]
     toJSON (RespTransactionByTxID tx) = object ["tx" .= tx]
     toJSON (RespTransactionsByTxIDs txs) = object ["txs" .= txs]
     toJSON (RespRawTransactionByTxID tx) = object ["rawTx" .= tx]

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -319,8 +319,8 @@ data ChainInfo =
         { ciChain :: String
         , ciChainWork :: String
         , ciDifficulty :: Double
-        , ciHeaders :: Int
-        , ciBlocks :: Int
+        , ciHeaders :: Int32
+        , ciBlocks :: Int32
         , ciBestBlockHash :: String
         } deriving (Generic, Show, Hashable, Eq, Serialise, ToJSON)
 

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -136,7 +136,7 @@ data RPCReqParams
 instance FromJSON RPCReqParams where
     parseJSON (Object o) =
         (AuthenticateReq <$> o .: "username" <*> o .: "password") <|>
-        (GeneralReq <$> o .: "sessionKey" <*> o .: "methodParams")
+        (GeneralReq <$> o .: "sessionKey" <*> o .:? "methodParams")
 
 data RPCReqParams'
     = GetBlockByHeight

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -151,9 +151,6 @@ data RPCReqParams'
     | GetBlocksByHashes
           { gbBlockHashes :: [String]
           }
-    | GetChainInfo
-          { gcChainInfo :: String
-          }
     | GetTransactionByTxID
           { gtTxHash :: String
           }
@@ -211,7 +208,6 @@ instance FromJSON RPCReqParams' where
         (GetBlockByHeight <$> o .: "gbHeight") <|> (GetBlocksByHeight <$> o .: "gbHeights") <|>
         (GetBlockByHash <$> o .: "gbBlockHash") <|>
         (GetBlocksByHashes <$> o .: "gbBlockHashes") <|>
-        (GetChainInfo <$> o .: "gcChainInfo") <|>
         (GetTransactionByTxID <$> o .: "gtTxHash") <|>
         (GetTransactionsByTxIDs <$> o .: "gtTxHashes") <|>
         (GetRawTransactionByTxID <$> o .: "gtRTxHash") <|>

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -245,7 +245,7 @@ data RPCResponseBody
           { blocks :: [BlockRecord]
           }
     | RespChainInfo
-          { chainwork :: String
+          { chainInfo :: ChainInfo
           }
     | RespTransactionByTxID
           { tx :: TxRecord
@@ -313,6 +313,16 @@ data AuthResp =
         , callsRemaining :: Int
         }
     deriving (Generic, Show, Hashable, Eq, Serialise, ToJSON)
+
+data ChainInfo =
+    ChainInfo
+        { ciChain :: String
+        , ciChainWork :: String
+        , ciDifficulty :: Double
+        , ciHeaders :: Int
+        , ciBlocks :: Int
+        , ciBestBlockHash :: String
+        } deriving (Generic, Show, Hashable, Eq, Serialise, ToJSON)
 
 data BlockRecord =
     BlockRecord

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -708,15 +708,3 @@ handleIfAllegoryTx tx revert = do
         case eres of
             Right () -> return True
             Left (SomeException e) -> throw e
-
--- Chainwork calculation
-
-targetMax :: Integer
-targetMax = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-
-convertBitsToTarget :: Int -> Integer
-convertBitsToTarget b = read $ "0x" ++ (drop 2 hexBits) ++ replicate ((read $ "0x" ++ take 2 hexBits)*2 - 6) '0'
-    where hexBits = showHex b ""
-
-getBlockWork :: Integer -> Integer
-getBlockWork = div targetMax

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -64,6 +64,7 @@ import qualified Database.Bolt as BT
 import qualified Database.CQL.IO as Q
 import qualified Database.CQL.IO as Q
 import Database.CQL.Protocol
+import Numeric (showHex)
 import qualified Network.Socket as NS
 import qualified Network.Socket.ByteString as SB (recv)
 import qualified Network.Socket.ByteString.Lazy as LB (recv, sendAll)
@@ -707,3 +708,15 @@ handleIfAllegoryTx tx revert = do
         case eres of
             Right () -> return True
             Left (SomeException e) -> throw e
+
+-- Chainwork calculation
+
+targetMax :: Integer
+targetMax = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+convertBitsToTarget :: Int -> Integer
+convertBitsToTarget b = read $ "0x" ++ (drop 2 hexBits) ++ replicate ((read $ "0x" ++ take 2 hexBits)*2 - 6) '0'
+    where hexBits = showHex b ""
+
+getBlockWork :: Integer -> Integer
+getBlockWork = div targetMax

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -64,7 +64,6 @@ import qualified Database.Bolt as BT
 import qualified Database.CQL.IO as Q
 import qualified Database.CQL.IO as Q
 import Database.CQL.Protocol
-import Numeric (showHex)
 import qualified Network.Socket as NS
 import qualified Network.Socket.ByteString as SB (recv)
 import qualified Network.Socket.ByteString.Lazy as LB (recv, sendAll)

--- a/node/src/Network/Xoken/Node/P2P/ChainSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/ChainSync.hs
@@ -58,7 +58,6 @@ import Network.Xoken.Node.Env
 import Network.Xoken.Node.GraphDB
 import Network.Xoken.Node.P2P.Common
 import Network.Xoken.Node.P2P.Types
-import Numeric
 import Streamly
 import Streamly.Prelude ((|:), nil)
 import qualified Streamly.Prelude as S
@@ -322,18 +321,5 @@ updateChainWork indexed conn = do
     case res of
         Right () -> return ()
         Left (e :: SomeException) -> do
-            err lg $ LG.msg ("Error: INSERT 'cahin-work' into 'misc_store' failed: " ++ show e)
+            err lg $ LG.msg ("Error: INSERT 'chain-work' into 'misc_store' failed: " ++ show e)
             throw KeyValueDBInsertException
-
-targetMax :: Integer
-targetMax = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-
-convertBitsToTarget :: Word32 -> Integer
-convertBitsToTarget b = read $ "0x" ++ (drop 2 hexBits) ++ replicate ((read $ "0x" ++ take 2 hexBits)*2 - 6) '0'
-    where hexBits = showHex b ""
-
-getBlockWork :: Integer -> Integer
-getBlockWork = div targetMax
-
-convertBitsToBlockWork :: Word32 -> Integer
-convertBitsToBlockWork = getBlockWork . convertBitsToTarget

--- a/node/src/Network/Xoken/Node/P2P/ChainSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/ChainSync.hs
@@ -314,9 +314,10 @@ updateChainWork indexed conn = do
         indexedCW = foldr (\x y -> y + (convertBitsToBlockWork $ blockBits $ fst $ snd $ x)) 0 indexed
     iop <- Q.runClient conn (Q.query qstr par)
     let (_, _, _, chainWork) = case L.length iop of
-           0 -> (Nothing, Just 0, Nothing, Just "4295032833")  -- 4295032833 is chainwork for genesis block
+           0 -> (Nothing, Just 0, Nothing, Just "4295032833")  -- 4295032833 (0x100010001) is chainwork for genesis block
            _ -> runIdentity $ iop !! 0
-        par1 = Q.defQueryParams Q.One ("chain-work", (Nothing, fst $ last indexed, Nothing, T.pack $ show $ indexedCW + (read . T.unpack $ fromJust chainWork)))
+        updatedChainwork = T.pack $ show $ indexedCW + (read . T.unpack $ fromJust chainWork)
+        par1 = Q.defQueryParams Q.One ("chain-work", (Nothing, fst $ last indexed, Nothing, updatedChainwork))
     res <- liftIO $ try $ Q.runClient conn (Q.write (Q.prepared qstr1) par1)
     case res of
         Right () -> return ()

--- a/node/src/Network/Xoken/Node/P2P/ChainSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/ChainSync.hs
@@ -307,31 +307,40 @@ fetchMatchBlockOffset conn net hashes = do
 updateChainWork :: (HasLogger m, MonadIO m) => [(Int32, BlockHeaderCount)] -> Q.ClientState -> m ()
 updateChainWork indexed conn = do
     lg <- getLogger
-    let str = "SELECT value from xoken.misc_store where key = ?"
-        qstr = str :: Q.QueryString Q.R (Identity Text) (Identity (Maybe Bool, Int32, Maybe Int64, T.Text))
-        str1 = "insert INTO xoken.misc_store (key, value) values (?, ?)"
-        qstr1 = str1 :: Q.QueryString Q.W (Text, (Maybe Bool, Int32, Maybe Int64, Text)) ()
-        par = Q.defQueryParams Q.One $ Identity "chain-work"
-        lenInd = L.length indexed
-        lagIndexed = take (lenInd - 10) indexed
-        indexedCW = foldr (\x y -> y + (convertBitsToBlockWork $ blockBits $ fst $ snd $ x)) 0 lagIndexed
-    res <- liftIO $ try $ Q.runClient conn (Q.query qstr par)
-    case res of
-        Right iop -> do
-            let (_, height, _, chainWork) = case L.length iop of
-                    0 -> (Nothing, 0, Nothing, "4295032833")  -- 4295032833 (0x100010001) is chainwork for genesis block
-                    _ -> runIdentity $ iop !! 0
-                lag = [(height + 1)..((fst $ head lagIndexed) - 1)]
-            lagCW <- calculateChainWork lag conn
-            let updatedChainwork = T.pack $ show $ lagCW + indexedCW + (read . T.unpack $ chainWork)
-                par1 = Q.defQueryParams Q.One ("chain-work", (Nothing, fst $ last lagIndexed, Nothing, updatedChainwork))
-            res1 <- liftIO $ try $ Q.runClient conn (Q.write (Q.prepared qstr1) par1)
-            case res1 of
-                Right () -> return ()
-                Left (e :: SomeException) -> do
-                    err lg $ LG.msg ("Error: INSERT 'chain-work' into 'misc_store' failed: " ++ show e)
-                    throw KeyValueDBInsertException
-        Left (e :: SomeException) -> do
-            err lg $ LG.msg ("Error: SELECT from 'misc_store' failed: " ++ show e)
-            throw KeyValueDBLookupException
+    if L.length indexed == 0
+        then do
+            debug lg $ LG.msg $ val "updateChainWork: Input list empty. Nothing updated."
+            return ()
+    else do
+        let str = "SELECT value from xoken.misc_store where key = ?"
+            qstr = str :: Q.QueryString Q.R (Identity Text) (Identity (Maybe Bool, Int32, Maybe Int64, T.Text))
+            str1 = "insert INTO xoken.misc_store (key, value) values (?, ?)"
+            qstr1 = str1 :: Q.QueryString Q.W (Text, (Maybe Bool, Int32, Maybe Int64, Text)) ()
+            par = Q.defQueryParams Q.One $ Identity "chain-work"
+            lenInd = L.length indexed
+            lenOffset = fromIntegral $ if lenInd <= 10 then (10 - lenInd) else 0
+            lagIndexed = take (lenInd - 10) indexed
+            indexedCW = foldr (\x y -> y + (convertBitsToBlockWork $ blockBits $ fst $ snd $ x)) 0 lagIndexed
+        res <- liftIO $ try $ Q.runClient conn (Q.query qstr par)
+        case res of
+            Right iop -> do
+                let (_, height, _, chainWork) = case L.length iop of
+                        0 -> (Nothing, 0, Nothing, "4295032833")  -- 4295032833 (0x100010001) is chainwork for genesis block
+                        _ -> runIdentity $ iop !! 0
+                    lag = [(height + 1)..((fst $ head indexed) - (1 + lenOffset))]
+                lagCW <- calculateChainWork lag conn
+                let updatedChainwork = T.pack $ show $ lagCW + indexedCW + (read . T.unpack $ chainWork)
+                    updatedBlock = if L.null lagIndexed then last lag else fst $ last lagIndexed
+                    par1 = Q.defQueryParams Q.One ("chain-work", (Nothing, updatedBlock, Nothing, updatedChainwork))
+                res1 <- liftIO $ try $ Q.runClient conn (Q.write (Q.prepared qstr1) par1)
+                case res1 of
+                    Right () -> do
+                        debug lg $ LG.msg $ val $ ("updateChainWork: updated till block" <> (C.pack $ show updatedBlock))
+                        return ()
+                    Left (e :: SomeException) -> do
+                        err lg $ LG.msg ("Error: INSERT 'chain-work' into 'misc_store' failed: " ++ show e)
+                        throw KeyValueDBInsertException
+            Left (e :: SomeException) -> do
+                err lg $ LG.msg ("Error: SELECT from 'misc_store' failed: " ++ show e)
+                throw KeyValueDBLookupException
     

--- a/node/src/Network/Xoken/Node/P2P/Common.hs
+++ b/node/src/Network/Xoken/Node/P2P/Common.hs
@@ -43,7 +43,6 @@ import qualified Data.Text as T
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Word
-import Data.Word
 import qualified Database.CQL.IO as Q
 import Network.Socket
 import qualified Network.Socket.ByteString as SB (recv)

--- a/node/src/Network/Xoken/Node/P2P/Common.hs
+++ b/node/src/Network/Xoken/Node/P2P/Common.hs
@@ -107,6 +107,14 @@ data PeerMessageException
 
 instance Exception PeerMessageException
 
+data AriviServiceException
+    = KeyValueDBLookupException
+    | GraphDBLookupException
+    | InvalidOutputAddressException
+    deriving (Show)
+
+instance Exception AriviServiceException
+
 --
 --
 -- | Create version data structure.

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -93,14 +93,6 @@ import Text.Read
 import Xoken
 import qualified Xoken.NodeConfig as NC
 
-data AriviServiceException
-    = KeyValueDBLookupException
-    | GraphDBLookupException
-    | InvalidOutputAddressException
-    deriving (Show)
-
-instance Exception AriviServiceException
-
 data EncodingFormat
     = CBOR
     | JSON

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -112,9 +112,11 @@ data EndPointConnection =
         , isAuthenticated :: TVar Bool
         }
 
-xGetChainInfo :: (HasXokenNodeEnv env m, HasLogger m, MonadIO m) => Network -> String -> m (Maybe String)
-xGetChainInfo net hash = do
-    return $ Just "0x1001001"
+xGetChainInfo :: (HasXokenNodeEnv env m, HasLogger m, MonadIO m) => Network -> m (Maybe String)
+xGetChainInfo net = do
+    lg <- getLogger
+    debug lg $ LG.msg $ ("Returning 0x1001001 Chainwork" :: String)
+    return $ Just $ "0x1001001"
 
 xGetBlockHash :: (HasXokenNodeEnv env m, HasLogger m, MonadIO m) => Network -> String -> m (Maybe BlockRecord)
 xGetBlockHash net hash = do
@@ -841,7 +843,7 @@ goGetResource msg net = do
         "CHAIN_INFO" -> do
             case rqParams msg of
                 Just (GetChainInfo hs) -> do
-                    cw <- xGetChainInfo net (hs)
+                    cw <- xGetChainInfo net
                     case cw of
                         Just c -> return $ RPCResponse 200 Nothing $ Just $ RespChainInfo c
                         Nothing -> return $ RPCResponse 404 (Just INVALID_REQUEST) Nothing

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -890,13 +890,10 @@ goGetResource msg net = do
     let grdb = graphDB (dbe)
     case rqMethod msg of
         "CHAIN_INFO" -> do
-            case methodParams $ rqParams msg of
-                Just (GetChainInfo hs) -> do
-                    cw <- xGetChainInfo net
-                    case cw of
-                        Just c -> return $ RPCResponse 200 Nothing $ Just $ RespChainInfo c
-                        Nothing -> return $ RPCResponse 404 (Just INVALID_REQUEST) Nothing
-                _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
+            cw <- xGetChainInfo net
+            case cw of
+                Just c -> return $ RPCResponse 200 Nothing $ Just $ RespChainInfo c
+                Nothing -> return $ RPCResponse 404 (Just INVALID_REQUEST) Nothing
         "HASH->BLOCK" -> do
             case methodParams $ rqParams msg of
                 Just (GetBlockByHash hs) -> do


### PR DESCRIPTION
- Data.hs
  - Added GetChainInfo to RPCReqParams' andRespChainInfo (ChainInfo data type) to RPCResponseBody

- ChainSync.hs
  - Added updateChainwork function to update 'chain-work' in misc_store
  - It is called in processHeaders before marking best block. It updateChainwork for except last 10 blocks. Whenever we call it, it first gets chainwork for blocks it hasn't calculated, then the new ones apart from last 10.

- XokenService.hs
  - Added xGetChainInfo and updated goGetResource to accomodate the same.

- Common.hs
  - Moved AriviServiceException from XokenService.hs to here
  - Added calculateChainwork that takes a list of block height and calculate the work required for them