### PR TITLE
173126319 get spent status

### DIFF
--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -257,7 +257,7 @@ data RPCResponseBody
           { psaTx :: ByteString
           }
     | RespTxOutputSpendStatus
-          { spendStatus :: TxOutputSpendStatus
+          { spendStatus :: Maybe TxOutputSpendStatus
           }
     deriving (Generic, Show, Hashable, Eq, Serialise)
 

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -374,7 +374,6 @@ data AddressOutputs =
         , aoOutput :: OutPoint'
         , aoBlockInfo :: BlockInfo'
         , aoNominalTxIndex :: Int64
-        , aoIsBlockConfirmed :: Bool
         , aoIsOutputSpent :: Bool
         , aoIsTypeReceive :: Bool
         , aoOtherAddress :: String
@@ -392,7 +391,6 @@ data ScriptOutputs =
         , scOutput :: OutPoint'
         , scBlockInfo :: BlockInfo'
         , scNominalTxIndex :: Int64
-        , scIsBlockConfirmed :: Bool
         , scIsOutputSpent :: Bool
         , scIsTypeReceive :: Bool
         , scOtherAddress :: String
@@ -490,7 +488,6 @@ addressToScriptOutputs AddressOutputs {..} =
         , scOutput = aoOutput
         , scBlockInfo = aoBlockInfo
         , scNominalTxIndex = aoNominalTxIndex
-        , scIsBlockConfirmed = aoIsBlockConfirmed
         , scIsOutputSpent = aoIsOutputSpent
         , scIsTypeReceive = aoIsTypeReceive
         , scOtherAddress = aoOtherAddress

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -391,6 +391,7 @@ fetchBestSyncedBlock conn net = do
                         Nothing -> throw InvalidBlockHashException
                 Nothing -> throw InvalidMetaDataException
 
+{-
 commitAddressOutputs ::
        (HasLogger m, MonadIO m)
     => Q.ClientState
@@ -426,6 +427,76 @@ commitAddressOutputs conn addr typeRecv otherAddr output blockInfo prevOutpoint 
         Right () -> return ()
         Left (e :: SomeException) -> do
             err lg $ LG.msg $ "Error: INSERTing into 'address_outputs': " ++ show e
+            throw KeyValueDBInsertException
+-}
+
+-- Keep the address_outputs schema unchanged for now but also add txid_outputs
+commitAddressOutputs ::
+        (HasLogger m, MonadIO m)
+     => Q.ClientState
+     -> Text                    -- address
+     -> Bool                    -- isTypeRecv
+     -> Maybe Text              -- otherAddr
+     -> (Text, Int32)           -- output (txid, index)
+     -> ((Text, Int32), Int32)  -- blockInfo ((blockHash, blockHeight), blockTxIndex)
+     -> (Text, Int32)           -- prevOutpoint (txid, index)
+     -> Int64                   -- value
+     -> m ()
+commitAddressOutputs conn addr typeRecv otherAddr output blockInfo prevOutpoint value = do
+    lg <- getLogger
+    let blkHeight = fromIntegral $ snd . fst $ blockInfo
+        txIndex = fromIntegral $ snd blockInfo
+        nominalTxIndex = blkHeight * 1000000000 + txIndex
+        txID = fst $ output
+        txIndex32 = snd $ output
+--        strAddrOuts = "INSERT INTO xoken.address_outputs (address, nominal_tx_index, output, is_type_receive, other_address) VALUES (?,?,?,?,?)"
+--        qstrAddrOuts =
+--            strAddrOuts :: Q.QueryString Q.W ( Text
+--                                             , Int64
+--                                             , (Text, Int32)
+--                                             , Bool
+--                                             , Maybe Text) ()
+--        parAddrOuts = Q.defQueryParams Q.One (addr, nominalTxIndex, output, typeRecv, otherAddr)
+--        batchStr =
+--            " BEGIN BATCH"
+--         ++ " INSERT INTO xoken.address_outputs (address, is_type_receive, other_address, output, block_info, nominal_tx_index, prev_outpoint, value, is_block_confirmed, is_output_spent) VALUES (?,?,?,?,?,?,?,?,?,?)"
+--         ++ " INSERT INTO xoken.txid_outputs (txid, index, block_info, is_output_spent, spending_txid, spending_index, prev_outpoint, value) VALUES (?,?,?,?,?,?,?,?,?,?)"
+--         ++ " APPLY BATCH";
+        strAddrOuts = "INSERT INTO xoken.address_outputs (address, is_type_receive, other_address, output, block_info, nominal_tx_index, prev_outpoint, value, is_block_confirmed, is_output_spent) VALUES (?,?,?,?,?,?,?,?,?,?)"
+        qstrAddrOuts =
+            strAddrOuts :: Q.QueryString Q.W ( Text
+                                             , Bool
+                                             , Maybe Text
+                                             , (Text, Int32)
+                                             , ((Text,Int32), Int32)
+                                             , Int64
+                                             , (Text, Int32)
+                                             , Int64
+                                             , Bool
+                                             , Bool) ()
+        parAddrOuts = Q.defQueryParams Q.One (addr, typeRecv, otherAddr, output, blockInfo, nominalTxIndex, prevOutpoint, value, False, False)
+        strTxIDOuts = "INSERT INTO xoken.txid_outputs (txid, idx, block_info, is_output_spent, spending_txid, spending_index, prev_outpoint, value) VALUES (?,?,?,?,?,?,?,?)"
+        qstrTxIDOuts =
+            strTxIDOuts :: Q.QueryString Q.W ( Text
+                                             , Int32
+                                             , ((Text, Int32), Int32)
+                                             , Bool
+                                             , Maybe Text
+                                             , Maybe Int32
+                                             , (Text, Int32)
+                                             , Int64) ()
+        parTxIDOuts = Q.defQueryParams Q.One (txID, txIndex32, blockInfo, False, Nothing, Nothing, prevOutpoint, value)
+    resAddrOuts <- liftIO $ try $ Q.runClient conn (Q.write (qstrAddrOuts) parAddrOuts)
+    resTxIDOuts <- liftIO $ try $ Q.runClient conn (Q.write (qstrTxIDOuts) parTxIDOuts)
+    case resAddrOuts of
+        Right () -> return ()
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: INSERTing into 'address_outputs': " ++ show e
+            throw KeyValueDBInsertException
+    case resTxIDOuts of
+        Right () -> return ()
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: INSERTing into 'txid_outputs': " ++ show e
             throw KeyValueDBInsertException
 
 processConfTransaction :: (HasXokenNodeEnv env m, HasLogger m, MonadIO m) => Tx -> BlockHash -> Int -> Int -> m ()

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -407,48 +407,6 @@ fetchBestSyncedBlock conn net = do
                         Nothing -> throw InvalidBlockHashException
                 Nothing -> throw InvalidMetaDataException
 
-{-
-commitAddressOutputs ::
-       (HasLogger m, MonadIO m)
-    => Q.ClientState
-    -> Text
-    -> Bool
-    -> Maybe Text
-    -> (Text, Int32)
-    -> ((Text, Int32), Int32)
-    -> (Text, Int32)
-    -> Int64
-    -> m ()
-commitAddressOutputs conn addr typeRecv otherAddr output blockInfo prevOutpoint value = do
-    lg <- getLogger
-    let blkHeight = fromIntegral $ snd . fst $ blockInfo
-        txIndex = fromIntegral $ snd blockInfo
-        nominalTxIndex = blkHeight * 1000000000 + txIndex
-        str =
-            "insert INTO xoken.address_outputs ( address, is_type_receive,other_address, output, block_info, nominal_tx_index, prev_outpoint, value, is_block_confirmed, is_output_spent ) values (?, ?, ?, ?, ?, ? ,? ,? ,?, ?)"
-        qstr =
-            str :: Q.QueryString Q.W ( Text
-                                     , Bool
-                                     , Maybe Text
-                                     , (Text, Int32)
-                                     , ((Text, Int32), Int32)
-                                     , Int64
-                                     , (Text, Int32)
-                                     , Int64
-                                     , Bool
-                                     , Bool) ()
-        par =
-            Q.defQueryParams
-                Q.One
-                (addr, typeRecv, otherAddr, output, blockInfo, nominalTxIndex, prevOutpoint, value, False, False)
-    res1 <- liftIO $ try $ Q.runClient conn (Q.write (qstr) par)
-    case res1 of
-        Right () -> return ()
-        Left (e :: SomeException) -> do
-            err lg $ LG.msg $ "Error: INSERTing into 'address_outputs': " ++ show e
-            throw KeyValueDBInsertException
--}
-
 -- Keep the address_outputs schema unchanged for now but also add txid_outputs
 commitAddressOutputs ::
         (HasLogger m, MonadIO m)
@@ -489,6 +447,56 @@ commitAddressOutputs conn addr typeRecv otherAddr output blockInfo prevOutpoint 
                                              , Bool
                                              , Bool) ()
         parAddrOuts = Q.defQueryParams Q.One (addr, typeRecv, otherAddr, output, blockInfo, nominalTxIndex, prevOutpoint, value, False, False)
+        strTxIDOuts = "INSERT INTO xoken.txid_outputs (txid, idx, block_info, is_output_spent, spending_txid, spending_index, prev_outpoint, value) VALUES (?,?,?,?,?,?,?,?)"
+        qstrTxIDOuts =
+            strTxIDOuts :: Q.QueryString Q.W ( Text
+                                             , Int32
+                                             , ((Text, Int32), Int32)
+                                             , Bool
+                                             , Maybe Text
+                                             , Maybe Int32
+                                             , (Text, Int32)
+                                             , Int64) ()
+        parTxIDOuts = Q.defQueryParams Q.One (txID, txIndex32, blockInfo, False, Nothing, Nothing, prevOutpoint, value)
+    resAddrOuts <- liftIO $ try $ Q.runClient conn (Q.write (qstrAddrOuts) parAddrOuts)
+    case resAddrOuts of
+        Right () -> do
+            resTxIDOuts <- liftIO $ try $ Q.runClient conn (Q.write (qstrTxIDOuts) parTxIDOuts)
+            case resTxIDOuts of
+                Right () -> return ()
+                Left (e :: SomeException) -> do
+                    err lg $ LG.msg $ "Error: INSERTing into 'txid_outputs':" ++ show e
+                    throw KeyValueDBInsertException
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: INSERTing into 'address_outputs': " ++ show e
+            throw KeyValueDBInsertException
+
+commitAddressOutputs' ::
+        (HasLogger m, MonadIO m)
+     => Q.ClientState
+     -> Text                    -- address
+     -> Bool                    -- isTypeRecv
+     -> Maybe Text              -- otherAddr
+     -> (Text, Int32)           -- output (txid, index)
+     -> ((Text, Int32), Int32)  -- blockInfo ((blockHash, blockHeight), blockTxIndex)
+     -> (Text, Int32)           -- prevOutpoint (txid, index)
+     -> Int64                   -- value
+     -> m ()
+commitAddressOutputs' conn addr typeRecv otherAddr output blockInfo prevOutpoint value = do
+    lg <- getLogger
+    let blkHeight = fromIntegral $ snd . fst $ blockInfo
+        txIndex = fromIntegral $ snd blockInfo
+        nominalTxIndex = blkHeight * 1000000000 + txIndex
+        txID = fst $ output
+        txIndex32 = snd $ output
+        strAddrOuts = "INSERT INTO xoken.address_outputs (address, nominal_tx_index, output, is_type_receive, other_address) VALUES (?,?,?,?,?)"
+        qstrAddrOuts =
+            strAddrOuts :: Q.QueryString Q.W ( Text
+                                             , Int64
+                                             , (Text, Int32)
+                                             , Bool
+                                             , Maybe Text) ()
+        parAddrOuts = Q.defQueryParams Q.One (addr, nominalTxIndex, output, typeRecv, otherAddr)
         strTxIDOuts = "INSERT INTO xoken.txid_outputs (txid, idx, block_info, is_output_spent, spending_txid, spending_index, prev_outpoint, value) VALUES (?,?,?,?,?,?,?,?)"
         qstrTxIDOuts =
             strTxIDOuts :: Q.QueryString Q.W ( Text

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -426,14 +426,6 @@ commitAddressOutputs conn addr typeRecv otherAddr output blockInfo prevOutpoint 
         nominalTxIndex = blkHeight * 1000000000 + txIndex
         txID = fst $ output
         txIndex32 = snd $ output
---        strAddrOuts = "INSERT INTO xoken.address_outputs (address, nominal_tx_index, output, is_type_receive, other_address) VALUES (?,?,?,?,?)"
---        qstrAddrOuts =
---            strAddrOuts :: Q.QueryString Q.W ( Text
---                                             , Int64
---                                             , (Text, Int32)
---                                             , Bool
---                                             , Maybe Text) ()
---        parAddrOuts = Q.defQueryParams Q.One (addr, nominalTxIndex, output, typeRecv, otherAddr)
         strAddrOuts = "INSERT INTO xoken.address_outputs (address, is_type_receive, other_address, output, block_info, nominal_tx_index, prev_outpoint, value, is_block_confirmed, is_output_spent) VALUES (?,?,?,?,?,?,?,?,?,?)"
         qstrAddrOuts =
             strAddrOuts :: Q.QueryString Q.W ( Text
@@ -471,6 +463,7 @@ commitAddressOutputs conn addr typeRecv otherAddr output blockInfo prevOutpoint 
             err lg $ LG.msg $ "Error: INSERTing into 'address_outputs': " ++ show e
             throw KeyValueDBInsertException
 
+-- switch to this after address_outputs loses fat 
 commitAddressOutputs' ::
         (HasLogger m, MonadIO m)
      => Q.ClientState

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -1013,7 +1013,7 @@ goGetResource msg net = do
                             return $ RPCResponse 400 (Just INTERNAL_ERROR) Nothing
                 _____ -> return $ RPCResponse 400 (Just INVALID_PARAMS) Nothing
         "TX_SPEND_STATUS" -> do
-            case rqParams msg of
+            case methodParams $ rqParams msg of
                 Just (GetTxOutputSpendStatus txid index) -> do
                     txss <- xGetTxOutputSpendStatus net txid index
                     return $ RPCResponse 200 Nothing $ Just $ RespTxOutputSpendStatus txss

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -389,7 +389,6 @@ xGetOutputsAddress net address pgSize mbNomTxInd = do
                             (OutPoint' (DT.unpack op_txid) (fromIntegral op_txidx))
                             (BlockInfo' (DT.unpack bsh) (fromIntegral bidx) (fromIntegral bht))
                             nti
-                            False
                             ios
                             itr
                             (if isJust oa

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -325,6 +325,33 @@ xGetTxHashes net hashes = do
                              (fromBlob sz))
                     iop
 
+getTxOutputsData ::
+       (HasXokenNodeEnv env m, HasLogger m, MonadIO m)
+    => Network
+    -> (DT.Text, Int32)
+    -> m (((DT.Text, Int32), Int32), Bool, (DT.Text, Int32), Int64)
+getTxOutputsData net (txid, idx) = do
+    dbe <- getDB
+    lg <- getLogger
+    let conn = keyValDB (dbe)
+        toStr = "SELECT block_info,is_output_spent,prev_outpoint,value FROM xoken.txid_outputs WHERE txid=? AND idx=?"
+        toQStr =
+            toStr :: Q.QueryString Q.R (DT.Text, Int32) ( ((DT.Text, Int32), Int32)
+                                                        , Bool
+                                                        , (DT.Text, Int32)
+                                                        , Int64)
+        top = Q.defQueryParams Q.One (txid, idx)
+    toRes <- LE.try $ Q.runClient conn (Q.query toQStr top)
+    case toRes of
+        Right es -> do
+            if length es == 0
+            then do err lg $ LG.msg $ "Error: getTxOutputsData: No entry in txid_outputs for (txid,idx): " ++ show (txid,idx)
+                    throw KeyValueDBLookupException
+            else return (es !! 0)
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: getTxOutputsData: " ++ show e
+            throw KeyValueDBLookupException
+
 xGetOutputsAddress ::
        (HasXokenNodeEnv env m, HasLogger m, MonadIO m)
     => Network
@@ -340,80 +367,36 @@ xGetOutputsAddress net address pgSize mbNomTxInd = do
             case mbNomTxInd of
                 (Just n) -> n
                 Nothing -> maxBound
-        str =
-            "SELECT address,output,block_info,nominal_tx_index,is_block_confirmed,is_output_spent,is_type_receive,other_address,prev_outpoint,value from xoken.address_outputs where address = ? and nominal_tx_index < ?"
-        qstr =
-            str :: Q.QueryString Q.R (DT.Text, Int64) ( DT.Text
-                                                      , (DT.Text, Int32)
-                                                      , ((DT.Text, Int32), Int32)
-                                                      , Int64
-                                                      , Bool
-                                                      , Bool
-                                                      , Bool
-                                                      , Maybe DT.Text
-                                                      , (DT.Text, Int32)
-                                                      , Int64)
-        p = Q.defQueryParams Q.One (DT.pack address, nominalTxIndex)
-    res <- LE.try $ Q.runClient conn (Q.query qstr (p {pageSize = pgSize}))
-    case res of
-        Right iop -> do
-            if length iop == 0
-                then return []
-                else do
-                    return $
-                        Data.List.map
-                            (\(addr, (txhs, ind), ((bhash, blkht), txind), nomTxInd, fconf, fospent, freceive, oaddr, (ptxhs, pind), val) ->
-                                 AddressOutputs
-                                     (DT.unpack addr)
-                                     (OutPoint' (DT.unpack txhs) (fromIntegral ind))
-                                     (BlockInfo' (DT.unpack bhash) (fromIntegral txind) (fromIntegral blkht))
-                                     nomTxInd
-                                     fconf
-                                     fospent
-                                     freceive
-                                     (if isJust oaddr
-                                          then DT.unpack $ fromJust oaddr
-                                          else "")
-                                     (OutPoint' (DT.unpack ptxhs) (fromIntegral pind))
-                                     val)
-                            iop
-        Left (e :: SomeException) -> do
-            err lg $ LG.msg $ "Error: xGetOutputsAddress: " ++ show e
-            throw KeyValueDBLookupException
-
-xGetOutputsAddress' ::
-       (HasXokenNodeEnv env m, HasLogger m, MonadIO m)
-    => Network
-    -> String
-    -> Maybe Int32
-    -> Maybe Int64
-    -> m ([AddressOutputs])
-xGetOutputsAddress' net address pgSize mbNomTxInd = do
-    dbe <- getDB
-    lg <- getLogger
-    let conn = keyValDB (dbe)
-        nominalTxIndex =
-            case mbNomTxInd of
-                (Just n) -> n
-                Nothing -> maxBound
-        str = "SELECT address,nominal_tx_index,output,is_type_receive,other_address FROM xoken.address_outputs WHERE address=? AND nominal_tx_index=?"
-        qstr =
-            str :: Q.QueryString Q.R (DT.Text, Int64) ( DT.Text
-                                                      , Int64
-                                                      , (DT.Text, Int32)
-                                                      , Bool
-                                                      , Maybe DT.Text)
-        p = Q.defQueryParams Q.One (DT.pack address, nominalTxIndex)
-    res <- LE.try $ Q.runClient conn (Q.query qstr (p {pageSize = pgSize}))
-    case res of
+        aoStr = "SELECT address,nominal_tx_index,output,is_type_receive,other_address FROM xoken.address_outputs WHERE address=? AND nominal_tx_index<?"
+        aoQStr =
+            aoStr :: Q.QueryString Q.R (DT.Text, Int64) ( DT.Text
+                                                        , Int64
+                                                        , (DT.Text, Int32)
+                                                        , Bool
+                                                        , Maybe DT.Text)
+        aop = Q.defQueryParams Q.One (DT.pack address, nominalTxIndex)
+    aoRes <- LE.try $ Q.runClient conn (Q.query aoQStr (aop {pageSize = pgSize}))
+    case aoRes of
         Right iop -> do
             if length iop == 0 
             then return []
             else do
---               return $ Data.List.map (\(addr, nomTxIndex, (txid, idx), isTypeReceive, otherAddress) ->
---                    AddressOutputs
---                        (DT.unpack addr)) iop 
-                return []
+                res <- sequence $ (\(_, _, (txid, idx), _, _) ->
+                    getTxOutputsData net (txid, idx)) <$> iop
+                return $ ((\((addr, nti, (op_txid, op_txidx), itr, oa), (((bsh, bht), bidx), ios, (oph, opi), val)) -> 
+                        AddressOutputs
+                            (DT.unpack addr)
+                            (OutPoint' (DT.unpack op_txid) (fromIntegral op_txidx))
+                            (BlockInfo' (DT.unpack bsh) (fromIntegral bidx) (fromIntegral bht))
+                            nti
+                            False
+                            ios
+                            itr
+                            (if isJust oa
+                                then DT.unpack $ fromJust oa
+                                else "")
+                            (OutPoint' (DT.unpack oph) (fromIntegral opi))
+                            val) <$>) (zip iop res)
         Left (e :: SomeException) -> do
             err lg $ LG.msg $ "Error: xGetOutputsAddress':" ++ show e
             throw KeyValueDBLookupException

--- a/schema.cql
+++ b/schema.cql
@@ -55,3 +55,15 @@ CREATE TABLE xoken.ep_transactions (
     tx_serialized blob,
     PRIMARY KEY (epoch, tx_id)
 ); 
+
+CREATE TABLE xoken.txid_outputs (
+     txid text,
+     idx int,
+     block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
+     is_output_spent boolean,
+     spending_txid text,
+     spending_index int,
+     prev_outpoint frozen<tuple<text, int>>,
+     value bigint,
+     PRIMARY KEY(txid, idx)
+ );

--- a/schema.cql
+++ b/schema.cql
@@ -34,22 +34,6 @@ CREATE TABLE xoken.ep_address_outputs (
 
 CREATE TABLE xoken.address_outputs (
     address text,
-    output frozen<tuple<text, int>>,
-    block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
-    nominal_tx_index bigint,
-    is_block_confirmed boolean,
-    is_output_spent boolean,
-    is_type_receive boolean,
-    other_address text,
-    prev_outpoint frozen<tuple<text, int>>,
-    value bigint,
-    PRIMARY KEY (address, nominal_tx_index, output)
-) WITH CLUSTERING ORDER BY (nominal_tx_index DESC); 
-
--- new schema
-
-CREATE TABLE xoken.address_outputs (
-    address text,
     nominal_tx_index bigint,
     output frozen<tuple<text, int>>,
     is_type_receive boolean,

--- a/schema.cql
+++ b/schema.cql
@@ -46,6 +46,17 @@ CREATE TABLE xoken.address_outputs (
     PRIMARY KEY (address, nominal_tx_index, output)
 ) WITH CLUSTERING ORDER BY (nominal_tx_index DESC); 
 
+-- new schema
+
+CREATE TABLE xoken.address_outputs (
+    address text,
+    nominal_tx_index bigint,
+    output frozen<tuple<text, int>>,
+    is_type_receive boolean,
+    other_address text,
+    PRIMARY KEY (address, nominal_tx_index, output)
+) WITH CLUSTERING ORDER BY (nominal_tx_index DESC);
+
 CREATE TABLE xoken.blocks_by_height (
     block_height int PRIMARY KEY,
     block_hash text,
@@ -78,14 +89,14 @@ CREATE TABLE xoken.user_permission (
 ); 
 
 CREATE TABLE xoken.txid_outputs (
-     txid text,
-     idx int,
-     block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
-     is_output_spent boolean,
-     spending_txid text,
-     spending_index int,
-     prev_outpoint frozen<tuple<text, int>>,
-     value bigint,
-     PRIMARY KEY(txid, idx)
+    txid text,
+    idx int,
+    block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
+    is_output_spent boolean,
+    spending_txid text,
+    spending_index int,
+    prev_outpoint frozen<tuple<text, int>>,
+    value bigint,
+    PRIMARY KEY(txid, idx)
  );
 


### PR DESCRIPTION
- Table xoken.address_outputs has been split into two tables; address_outputs and txid_outputs
- TX_SPEND_STATUS endpoint added to API that takes (txid, index) as params, as of now returns False
- Unused isBlockConfirmed removed from xoken.address_outputs and all *->OUTPUTS response, rest of the response structure unchanged