### PR TITLE
schema changes: txid_outputs, fix issue with block_info contents

### DIFF
--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -509,8 +509,8 @@ data OutPoint' =
 data BlockInfo' =
     BlockInfo'
         { binfBlockHash :: String
-        , binfTxIndex :: Int32
         , binfBlockHeight :: Int32
+        , binfTxIndex :: Int32
         }
     deriving (Show, Generic, Hashable, Eq, Serialise, ToJSON)
 

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -441,7 +441,7 @@ commitScriptHashOutputs ::
 commitScriptHashOutputs conn sh output blockInfo = do
     lg <- getLogger
     let blkHeight = fromIntegral $ snd3 blockInfo
-        txIndex = fromIntegral $ lst3 blockInfo 
+        txIndex = fromIntegral $ thd3 blockInfo 
         nominalTxIndex = blkHeight * 1000000000 + txIndex
         strAddrOuts = "INSERT INTO xoken.script_hash_outputs (script_hash, nominal_tx_index, output) VALUES (?,?,?)"
         qstrAddrOuts = strAddrOuts :: Q.QueryString Q.W (Text, Int64, (Text, Int32)) ()

--- a/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
@@ -215,10 +215,10 @@ insertEpochTxIdOutputs ::
     -> [((Text, Int32), Int32, Int64)]
     -> Int64
     -> m ()
-insertEpochTxIdOutputs conn epoch (txid, idx) inputs value = do
+insertEpochTxIdOutputs conn epoch (txid, index) inputs value = do
     lg <- getLogger
     let str =
-            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,idx,is_output_spent,spending_txid,spending_index,inputs,value) VALUES (?,?,?,?,?,?,?,?)"
+            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,indx,is_output_spent,spending_txid,spending_index,inputs,value) VALUES (?,?,?,?,?,?,?,?)"
         qstr =
             str :: Q.QueryString Q.W ( Bool
                                      , Text
@@ -228,7 +228,7 @@ insertEpochTxIdOutputs conn epoch (txid, idx) inputs value = do
                                      , Maybe Int32
                                      , [((Text, Int32), Int32, Int64)]
                                      , Int64) ()
-        par = Q.defQueryParams Q.One (epoch, txid, idx, False, Nothing, Nothing, inputs, value)
+        par = Q.defQueryParams Q.One (epoch, txid, index, False, Nothing, Nothing, inputs, value)
     res <- liftIO $ try $ Q.runClient conn $ (Q.write qstr par)
     case res of
         Right () -> return ()
@@ -237,12 +237,12 @@ insertEpochTxIdOutputs conn epoch (txid, idx) inputs value = do
             throw KeyValueDBInsertException
 
 updateEpochTxIdOutputs :: (HasLogger m, MonadIO m) => Q.ClientState -> (Text, Int32) -> ((Text, Int32), Int32) -> m ()
-updateEpochTxIdOutputs conn (txid, idx) (prevOutpoint, inputIndex) = do
+updateEpochTxIdOutputs conn (txid, index) (prevOutpoint, inputIndex) = do
     lg <- getLogger
     let prevTxId = fst $ prevOutpoint
         prevIdx = snd $ prevOutpoint
         str =
-            "UPDATE xoken.ep_txid_outputs SET is_output_spent=?,spending_txid=?,spending_index=? WHERE txid=? AND idx=?"
+            "UPDATE xoken.ep_txid_outputs SET is_output_spent=?,spending_txid=?,spending_index=? WHERE txid=? AND indx=?"
         qstr = str :: Q.QueryString Q.W (Bool, Text, Int32, Text, Int32) ()
         par = Q.defQueryParams Q.One (True, txid, inputIndex, prevTxId, prevIdx)
     res <- liftIO $ try $ Q.runClient conn (Q.write qstr par)
@@ -377,7 +377,7 @@ processUnconfTransaction tx = do
 getSatValuesFromEpochOutpoint ::
        Q.ClientState -> (TVar (M.Map TxHash EV.Event)) -> Logger -> Network -> OutPoint -> Int -> IO (Int64)
 getSatValuesFromEpochOutpoint conn txSync lg net outPoint waitSecs = do
-    let str = "SELECT value FROM xoken.ep_txid_outputs WHERE txid=? AND idx=?"
+    let str = "SELECT value FROM xoken.ep_txid_outputs WHERE txid=? AND indx=?"
         qstr = str :: Q.QueryString Q.R (Text, Int32) (Identity Int64)
         par = Q.defQueryParams Q.One $ (txHashToHex $ outPointHash outPoint, fromIntegral $ outPointIndex outPoint)
     res <- liftIO $ try $ Q.runClient conn (Q.query qstr par)

--- a/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
@@ -218,7 +218,7 @@ insertEpochTxIdOutputs ::
 insertEpochTxIdOutputs conn epoch (txid, index) inputs value = do
     lg <- getLogger
     let str =
-            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,indx,is_output_spent,spending_txid,spending_index,inputs,value) VALUES (?,?,?,?,?,?,?,?)"
+            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,output_index,is_output_spent,spending_txid,spending_index,inputs,value) VALUES (?,?,?,?,?,?,?,?)"
         qstr =
             str :: Q.QueryString Q.W ( Bool
                                      , Text
@@ -242,7 +242,7 @@ updateEpochTxIdOutputs conn (txid, index) (prevOutpoint, inputIndex) = do
     let prevTxId = fst $ prevOutpoint
         prevIdx = snd $ prevOutpoint
         str =
-            "UPDATE xoken.ep_txid_outputs SET is_output_spent=?,spending_txid=?,spending_index=? WHERE txid=? AND indx=?"
+            "UPDATE xoken.ep_txid_outputs SET is_output_spent=?,spending_txid=?,spending_index=? WHERE txid=? AND output_index=?"
         qstr = str :: Q.QueryString Q.W (Bool, Text, Int32, Text, Int32) ()
         par = Q.defQueryParams Q.One (True, txid, inputIndex, prevTxId, prevIdx)
     res <- liftIO $ try $ Q.runClient conn (Q.write qstr par)
@@ -377,7 +377,7 @@ processUnconfTransaction tx = do
 getSatValuesFromEpochOutpoint ::
        Q.ClientState -> (TVar (M.Map TxHash EV.Event)) -> Logger -> Network -> OutPoint -> Int -> IO (Int64)
 getSatValuesFromEpochOutpoint conn txSync lg net outPoint waitSecs = do
-    let str = "SELECT value FROM xoken.ep_txid_outputs WHERE txid=? AND indx=?"
+    let str = "SELECT value FROM xoken.ep_txid_outputs WHERE txid=? AND output_index=?"
         qstr = str :: Q.QueryString Q.R (Text, Int32) (Identity Int64)
         par = Q.defQueryParams Q.One $ (txHashToHex $ outPointHash outPoint, fromIntegral $ outPointIndex outPoint)
     res <- liftIO $ try $ Q.runClient conn (Q.query qstr par)

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -281,7 +281,7 @@ xGetTxOutputSpendStatus txId outputIndex = do
     dbe <- getDB
     let conn = keyValDB (dbe)
         str =
-            "SELECT is_output_spent, spending_txid, spending_index, spending_tx_block_height FROM xoken.txid_outputs WHERE txid=? AND idx=?"
+            "SELECT is_output_spent, spending_txid, spending_index, spending_tx_block_height FROM xoken.txid_outputs WHERE txid=? AND indx=?"
         qstr = str :: Q.QueryString Q.R (DT.Text, Int32) (Bool, Maybe DT.Text, Maybe Int32, Maybe Int32)
         p = Q.defQueryParams Q.One (DT.pack txId, outputIndex)
     iop <- Q.runClient conn (Q.query qstr p)
@@ -370,18 +370,18 @@ xGetTxHash hash = do
     dbe <- getDB
     let conn = keyValDB (dbe)
         str = "SELECT tx_id, block_info, tx_serialized from xoken.transactions where tx_id = ?"
-        qstr = str :: Q.QueryString Q.R (Identity DT.Text) (DT.Text, ((DT.Text, Int32), Int32), Blob)
+        qstr = str :: Q.QueryString Q.R (Identity DT.Text) (DT.Text, (DT.Text, Int32, Int32), Blob)
         p = Q.defQueryParams Q.One $ Identity $ hash
     iop <- Q.runClient conn (Q.query qstr p)
     if length iop == 0
         then return Nothing
         else do
-            let (txid, ((bhash, txind), blkht), sz) = iop !! 0
+            let (txid, (bhash, blkht, txind), sz) = iop !! 0
             return $
                 Just $
                 RawTxRecord
                     (DT.unpack txid)
-                    (BlockInfo' (DT.unpack bhash) (fromIntegral txind) (fromIntegral blkht))
+                    (BlockInfo' (DT.unpack bhash) (fromIntegral blkht) (fromIntegral txind))
                     (fromBlob sz)
 
 xGetTxHashes :: (HasXokenNodeEnv env m, MonadIO m) => [DT.Text] -> m ([RawTxRecord])
@@ -389,7 +389,7 @@ xGetTxHashes hashes = do
     dbe <- getDB
     let conn = keyValDB (dbe)
         str = "SELECT tx_id, block_info, tx_serialized from xoken.transactions where tx_id in ?"
-        qstr = str :: Q.QueryString Q.R (Identity [DT.Text]) (DT.Text, ((DT.Text, Int32), Int32), Blob)
+        qstr = str :: Q.QueryString Q.R (Identity [DT.Text]) (DT.Text, (DT.Text, Int32, Int32), Blob)
         p = Q.defQueryParams Q.One $ Identity $ hashes
     iop <- Q.runClient conn (Q.query qstr p)
     if length iop == 0
@@ -397,28 +397,28 @@ xGetTxHashes hashes = do
         else do
             return $
                 Data.List.map
-                    (\(txid, ((bhash, txind), blkht), sz) ->
+                    (\(txid, (bhash, blkht, txind), sz) ->
                          RawTxRecord
                              (DT.unpack txid)
-                             (BlockInfo' (DT.unpack bhash) (fromIntegral txind) (fromIntegral blkht))
+                             (BlockInfo' (DT.unpack bhash) (fromIntegral blkht) (fromIntegral txind))
                              (fromBlob sz))
                     iop
 
 getTxOutputsData ::
        (HasXokenNodeEnv env m, HasLogger m, MonadIO m)
     => (DT.Text, Int32)
-    -> m (((DT.Text, Int32), Int32), Bool, Set ((DT.Text, Int32), Int32, Int64), Int64)
-getTxOutputsData (txid, idx) = do
+    -> m ((DT.Text, Int32, Int32), Bool, Set ((DT.Text, Int32), Int32, Int64), Int64)
+getTxOutputsData (txid, index) = do
     dbe <- getDB
     lg <- getLogger
     let conn = keyValDB (dbe)
-        toStr = "SELECT block_info,is_output_spent,inputs,value FROM xoken.txid_outputs WHERE txid=? AND idx=?"
+        toStr = "SELECT block_info,is_output_spent,inputs,value FROM xoken.txid_outputs WHERE txid=? AND indx=?"
         toQStr =
-            toStr :: Q.QueryString Q.R (DT.Text, Int32) ( ((DT.Text, Int32), Int32)
+            toStr :: Q.QueryString Q.R (DT.Text, Int32) ( (DT.Text, Int32, Int32)
                                                         , Bool
                                                         , Set ((DT.Text, Int32), Int32, Int64)
                                                         , Int64)
-        top = Q.defQueryParams Q.One (txid, idx)
+        top = Q.defQueryParams Q.One (txid, index)
     toRes <- LE.try $ Q.runClient conn (Q.query toQStr top)
     case toRes of
         Right es -> do
@@ -426,7 +426,7 @@ getTxOutputsData (txid, idx) = do
                 then do
                     err lg $
                         LG.msg $
-                        "Error: getTxOutputsData: No entry in txid_outputs for (txid,idx): " ++ show (txid, idx)
+                        "Error: getTxOutputsData: No entry in txid_outputs for (txid,index): " ++ show (txid, index)
                     throw KeyValueDBLookupException
                 else return (es !! 0)
         Left (e :: SomeException) -> do
@@ -452,13 +452,13 @@ xGetOutputsAddress address pgSize mbNomTxInd = do
             if length iop == 0
                 then return []
                 else do
-                    res <- sequence $ (\(_, _, (txid, idx)) -> getTxOutputsData (txid, idx)) <$> iop
+                    res <- sequence $ (\(_, _, (txid, index)) -> getTxOutputsData (txid, index)) <$> iop
                     return $
-                        ((\((addr, nti, (op_txid, op_txidx)), (((bsh, bht), bidx), ios, ips, val)) ->
+                        ((\((addr, nti, (op_txid, op_txidx)), ((bsh, bht, bidx), ios, ips, val)) ->
                               AddressOutputs
                                   (DT.unpack addr)
                                   (OutPoint' (DT.unpack op_txid) (fromIntegral op_txidx))
-                                  (BlockInfo' (DT.unpack bsh) (fromIntegral bidx) (fromIntegral bht))
+                                  (BlockInfo' (DT.unpack bsh) (fromIntegral bht) (fromIntegral bidx))
                                   nti
                                   ios
                                   ((\((oph, opi), ii, ov) -> (OutPoint' (DT.unpack oph) (fromIntegral opi), fromIntegral ii, fromIntegral ov)) <$>
@@ -827,7 +827,7 @@ xRelayTx rawTx = do
                                          "SELECT tx_id, block_info, tx_serialized from xoken.transactions where tx_id = ?"
                                      qstr =
                                          str :: Q.QueryString Q.R (Identity DT.Text) ( DT.Text
-                                                                                     , ((DT.Text, Int32), Int32)
+                                                                                     , (DT.Text, Int32, Int32)
                                                                                      , Blob)
                                      p = Q.defQueryParams Q.One $ Identity $ (txid)
                                  iop <- Q.runClient conn (Q.query qstr p)

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -281,7 +281,7 @@ xGetTxOutputSpendStatus txId outputIndex = do
     dbe <- getDB
     let conn = keyValDB (dbe)
         str =
-            "SELECT is_output_spent, spending_txid, spending_index, spending_tx_block_height FROM xoken.txid_outputs WHERE txid=? AND indx=?"
+            "SELECT is_output_spent, spending_txid, spending_index, spending_tx_block_height FROM xoken.txid_outputs WHERE txid=? AND output_index=?"
         qstr = str :: Q.QueryString Q.R (DT.Text, Int32) (Bool, Maybe DT.Text, Maybe Int32, Maybe Int32)
         p = Q.defQueryParams Q.One (DT.pack txId, outputIndex)
     iop <- Q.runClient conn (Q.query qstr p)
@@ -412,7 +412,7 @@ getTxOutputsData (txid, index) = do
     dbe <- getDB
     lg <- getLogger
     let conn = keyValDB (dbe)
-        toStr = "SELECT block_info,is_output_spent,inputs,value FROM xoken.txid_outputs WHERE txid=? AND indx=?"
+        toStr = "SELECT block_info,is_output_spent,inputs,value FROM xoken.txid_outputs WHERE txid=? AND output_index=?"
         toQStr =
             toStr :: Q.QueryString Q.R (DT.Text, Int32) ( (DT.Text, Int32, Int32)
                                                         , Bool

--- a/schema.cql
+++ b/schema.cql
@@ -42,14 +42,14 @@ CREATE TABLE xoken.ep_script_hash_outputs (
 CREATE TABLE xoken.ep_txid_outputs (
     epoch boolean,
     txid text,
-    indx int,
+    output_index int,
     is_output_spent boolean,
     spending_txid text,
     spending_index int,
     inputs set  <frozen<tuple<frozen<tuple<text, int>>, int, bigint>>>,
     value bigint,
-    PRIMARY KEY(epoch, txid, indx)
- );
+    PRIMARY KEY(epoch, txid, output_index)
+ ) WITH CLUSTERING ORDER BY (output_index ASC);
 
 CREATE TABLE xoken.script_hash_outputs (
     script_hash text,
@@ -60,7 +60,7 @@ CREATE TABLE xoken.script_hash_outputs (
 
 CREATE TABLE xoken.txid_outputs (
     txid text,
-    indx int,
+    output_index int,
     block_info frozen<tuple<text, int, int>>,
     is_output_spent boolean,
     spending_txid text,
@@ -68,8 +68,8 @@ CREATE TABLE xoken.txid_outputs (
     spending_tx_block_height int,
     inputs set  <frozen<tuple<frozen<tuple<text, int>>, int, bigint>>>,
     value bigint,
-    PRIMARY KEY(txid, indx)
- ) WITH CLUSTERING ORDER BY (indx ASC);
+    PRIMARY KEY(txid, output_index)
+ ) WITH CLUSTERING ORDER BY (output_index ASC);
 
 CREATE TABLE xoken.blocks_by_height (
     block_height int PRIMARY KEY,

--- a/schema.cql
+++ b/schema.cql
@@ -7,7 +7,7 @@ CREATE TABLE xoken.misc_store (
 
 CREATE TABLE xoken.transactions (
     tx_id text PRIMARY KEY,
-    block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
+    block_info frozen<tuple<text, int, int>>,
     tx_serialized blob,
     inputs set  <frozen<tuple<frozen<tuple<text, int>>, int, bigint>>>,
     fees bigint
@@ -42,13 +42,13 @@ CREATE TABLE xoken.ep_script_hash_outputs (
 CREATE TABLE xoken.ep_txid_outputs (
     epoch boolean,
     txid text,
-    idx int,
+    indx int,
     is_output_spent boolean,
     spending_txid text,
     spending_index int,
     inputs set  <frozen<tuple<frozen<tuple<text, int>>, int, bigint>>>,
     value bigint,
-    PRIMARY KEY(epoch, txid, idx)
+    PRIMARY KEY(epoch, txid, indx)
  );
 
 CREATE TABLE xoken.script_hash_outputs (
@@ -60,16 +60,16 @@ CREATE TABLE xoken.script_hash_outputs (
 
 CREATE TABLE xoken.txid_outputs (
     txid text,
-    idx int,
-    block_info frozen<tuple<frozen<tuple<text, int>>, int>>,
+    indx int,
+    block_info frozen<tuple<text, int, int>>,
     is_output_spent boolean,
     spending_txid text,
     spending_index int,
     spending_tx_block_height int,
     inputs set  <frozen<tuple<frozen<tuple<text, int>>, int, bigint>>>,
     value bigint,
-    PRIMARY KEY(txid, idx)
- );
+    PRIMARY KEY(txid, indx)
+ ) WITH CLUSTERING ORDER BY (indx ASC);
 
 CREATE TABLE xoken.blocks_by_height (
     block_height int PRIMARY KEY,


### PR DESCRIPTION
- alter order of elements in BlockInfo' to (blockHash, blockHeight, blockTxIndex)
- alter block_info in schema to match BlockInfo' type: 
- fix an issue related to order of elements in block_info 
- alter schema: 
    - rename idx in epoch and normal txid_outputs to output_index
    - cluster normal and epoch txid_outputs by index (ascending order)
- remove unused insert/update switch params in txidOutputs functions