### PR TITLE
Restructure script_hash_outputs

### DIFF
--- a/node/src/Network/Xoken/Node/Env.hs
+++ b/node/src/Network/Xoken/Node/Env.hs
@@ -73,7 +73,7 @@ data BitcoinP2P =
         , blockTxProcessingLeftMap :: !(MVar (M.Map BlockHash [Bool]))
         , epochType :: !(TVar Bool)
         , unconfirmedTxCache :: !(HashTable TxShortHash (Bool, TxHash))
-        , txOutputValuesCache :: !(HashTable TxShortHash (TxHash, [(Int16, (Text, Int64))]))
+        , txOutputValuesCache :: !(HashTable TxShortHash (TxHash, [(Int16, (Text, Text, Int64))]))
         , peerReset :: !(MVar Bool, TVar Int)
         , merkleQueueMap :: !(TVar (M.Map BlockHash (TBQueue (TxHash, Bool))))
         , txSynchronizer :: !(MVar (M.Map TxHash Event))

--- a/node/src/Network/Xoken/Node/Env.hs
+++ b/node/src/Network/Xoken/Node/Env.hs
@@ -73,7 +73,7 @@ data BitcoinP2P =
         , blockTxProcessingLeftMap :: !(MVar (M.Map BlockHash [Bool]))
         , epochType :: !(TVar Bool)
         , unconfirmedTxCache :: !(HashTable TxShortHash (Bool, TxHash))
-        , txOutputValuesCache :: !(HashTable TxShortHash (TxHash, [(Int16, (Maybe Text, Int64))]))
+        , txOutputValuesCache :: !(HashTable TxShortHash (TxHash, [(Int16, (Text, Int64))]))
         , peerReset :: !(MVar Bool, TVar Int)
         , merkleQueueMap :: !(TVar (M.Map BlockHash (TBQueue (TxHash, Bool))))
         , txSynchronizer :: !(MVar (M.Map TxHash Event))

--- a/node/src/Network/Xoken/Node/P2P/BlockSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/BlockSync.hs
@@ -462,29 +462,57 @@ commitScriptHashOutputs conn sh output blockInfo = do
             err lg $ LG.msg $ "Error: INSERTing into 'script_hash_outputs': " ++ show e
             throw KeyValueDBInsertException
 
+commitScriptHashUnspentOutputs :: (HasLogger m, MonadIO m) => Q.ClientState -> Text -> (Text, Int32) -> m ()
+commitScriptHashUnspentOutputs conn sh output = do
+    lg <- getLogger
+    let str = "INSERT INTO xoken.script_hash_unspent_outputs (script_hash, output) VALUES (?,?)"
+        qstr = str :: Q.QueryString Q.W (Text, (Text, Int32)) ()
+        par = Q.defQueryParams Q.One (sh, output)
+    res <- liftIO $ try $ Q.runClient conn (Q.write qstr par)
+    case res of
+        Right () -> return ()
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: INSERTing into 'script_hash_unspent_outputs': " ++ show e
+            throw KeyValueDBInsertException
+
+deleteScriptHashUnspentOutputs :: (HasLogger m, MonadIO m) => Q.ClientState -> Text -> (Text, Int32) -> m ()
+deleteScriptHashUnspentOutputs conn sh output = do
+    lg <- getLogger
+    let str = "DELETE FROM xoken.script_hash_unspent_outputs WHERE script_hash=? AND output=?"
+        qstr = str :: Q.QueryString Q.W (Text, (Text, Int32)) ()
+        par = Q.defQueryParams Q.One (sh, output)
+    res <- liftIO $ try $ Q.runClient conn (Q.write qstr par)
+    case res of
+        Right () -> return ()
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: DELETE'ing from 'script_hash_unspent_outputs': " ++ show e
+            throw e
+
 insertTxIdOutputs ::
        (HasLogger m, MonadIO m)
     => Q.ClientState
     -> (Text, Int32)
+    -> Text
     -> Text
     -> Bool
     -> (Text, Int32, Int32)
     -> [((Text, Int32), Int32, (Text, Int64))]
     -> Int64
     -> m ()
-insertTxIdOutputs conn (txid, outputIndex) address isRecv blockInfo other value = do
+insertTxIdOutputs conn (txid, outputIndex) address scriptHash isRecv blockInfo other value = do
     lg <- getLogger
     let str =
-            "INSERT INTO xoken.txid_outputs (txid,output_index,address,is_recv,block_info,other,value) VALUES (?,?,?,?,?,?,?)"
+            "INSERT INTO xoken.txid_outputs (txid,output_index,address,script_hash,is_recv,block_info,other,value) VALUES (?,?,?,?,?,?,?,?)"
         qstr =
             str :: Q.QueryString Q.W ( Text
                                      , Int32
+                                     , Text
                                      , Text
                                      , Bool
                                      , (Text, Int32, Int32)
                                      , [((Text, Int32), Int32, (Text, Int64))]
                                      , Int64) ()
-        par = Q.defQueryParams Q.One (txid, outputIndex, address, isRecv, blockInfo, other, value)
+        par = Q.defQueryParams Q.One (txid, outputIndex, address, scriptHash, isRecv, blockInfo, other, value)
     res <- liftIO $ try $ Q.runClient conn $ (Q.write qstr par)
     case res of
         Right () -> return ()
@@ -560,6 +588,7 @@ processConfTransaction tx bhash txind blkht = do
                                      if (outPointHash nullOutPoint) == (outPointHash $ prevOutput b)
                                          then return
                                                   ( ""
+                                                  , ""
                                                   , fromIntegral $ computeSubsidy net $ (fromIntegral blkht :: Word32))
                                          else do
                                              trace lg $ LG.msg $ C.pack $ "txOutputValuesCache: cache-miss"
@@ -586,7 +615,8 @@ processConfTransaction tx bhash txind blkht = do
                                                      throw e
                          Nothing -> do
                              if (outPointHash nullOutPoint) == (outPointHash $ prevOutput b)
-                                 then return ("", fromIntegral $ computeSubsidy net $ (fromIntegral blkht :: Word32))
+                                 then return
+                                          ("", "", fromIntegral $ computeSubsidy net $ (fromIntegral blkht :: Word32))
                                  else do
                                      trace lg $ LG.msg $ C.pack $ "txOutputValuesCache: cache-miss"
                                      dbRes <-
@@ -616,7 +646,13 @@ processConfTransaction tx bhash txind blkht = do
     trace lg $ LG.msg $ "processing Transaction " ++ show (txHash tx) ++ ": fetched input(s): " ++ show inputs
     --
     -- cache compile output values 
-    let ovs = map (\(a, o, i) -> (fromIntegral $ i, (a, fromIntegral $ outValue o))) outAddrs
+    -- imp: order is (address, scriptHash, value)
+    let ovs =
+            map
+                (\(a, o, i) ->
+                     ( fromIntegral $ i
+                     , (a, (txHashToHex $ TxHash $ sha256 (scriptOutput o)), fromIntegral $ outValue o)))
+                outAddrs
     trace lg $ LG.msg $ "processing Transaction " ++ show (txHash tx) ++ ": compiled output value(s): " ++ (show ovs)
     liftIO $
         H.insert
@@ -631,26 +667,31 @@ processConfTransaction tx bhash txind blkht = do
              let sh = txHashToHex $ TxHash $ sha256 (scriptOutput o)
              let bi = (blockHashToHex bhash, fromIntegral blkht, fromIntegral txind)
              let output = (txHashToHex $ txHash tx, i)
-             insertTxIdOutputs conn output a True bi inputs (fromIntegral $ outValue o)
+             insertTxIdOutputs conn output a sh True bi (stripScriptHash <$> inputs) (fromIntegral $ outValue o)
              commitScriptHashOutputs
                  conn -- connection
                  sh -- scriptHash
                  output
-                 bi)
+                 bi
+             commitScriptHashUnspentOutputs conn sh output)
         outAddrs
     trace lg $ LG.msg $ "processing Transaction " ++ show (txHash tx) ++ ": committed scripthash,txid_outputs tables"
     mapM_
-        (\((o, i), a) -> do
+        (\((o, i), (a, sh)) -> do
              let bi = (blockHashToHex bhash, fromIntegral blkht, fromIntegral txind)
              let blockHeight = fromIntegral blkht
              let prevOutpoint = (txHashToHex $ outPointHash $ prevOutput o, fromIntegral $ outPointIndex $ prevOutput o)
              let spendInfo = (\ov -> ((txHashToHex $ txHash tx, fromIntegral $ fst $ ov), i, snd $ ov)) <$> ovs
-             insertTxIdOutputs conn prevOutpoint a False bi spendInfo 0)
-        (zip (inAddrs) (map (\x -> fst $ thd3 x) inputs))
+             if a == "" || sh == "" -- likely coinbase txns
+                 then return ()
+                 else do
+                     insertTxIdOutputs conn prevOutpoint a sh False bi (stripScriptHash <$> spendInfo) 0
+                     deleteScriptHashUnspentOutputs conn sh prevOutpoint)
+        (zip (inAddrs) (map (\x -> (fst3 $ thd3 x, snd3 $ thd3 $ x)) inputs))
     --
     trace lg $ LG.msg $ "processing Transaction " ++ show (txHash tx) ++ ": updated spend info for inputs"
     -- calculate Tx fees
-    let ipSum = foldl (+) 0 $ (\(_, _, (_, val)) -> val) <$> inputs
+    let ipSum = foldl (+) 0 $ (\(_, _, (_, _, val)) -> val) <$> inputs
         opSum = foldl (+) 0 $ (\(_, o, _) -> fromIntegral $ outValue o) <$> outAddrs
         fees = ipSum - opSum
     --
@@ -665,7 +706,7 @@ processConfTransaction tx bhash txind blkht = do
                 ( txHashToHex $ txHash tx
                 , (blockHashToHex bhash, fromIntegral blkht, fromIntegral txind)
                 , Blob $ runPutLazy $ putLazyByteString $ S.encodeLazy tx
-                , inputs
+                , (stripScriptHash <$> inputs)
                 , fees)
     res <- liftIO $ try $ Q.runClient conn (Q.write (qstr) par)
     case res of
@@ -691,10 +732,16 @@ processConfTransaction tx bhash txind blkht = do
     trace lg $ LG.msg $ "processing Transaction " ++ show (txHash tx) ++ ": end of processing signaled"
 
 getSatValuesFromOutpoint ::
-       Q.ClientState -> (MVar (M.Map TxHash EV.Event)) -> Logger -> Network -> OutPoint -> Int -> IO ((Text, Int64))
+       Q.ClientState
+    -> (MVar (M.Map TxHash EV.Event))
+    -> Logger
+    -> Network
+    -> OutPoint
+    -> Int
+    -> IO ((Text, Text, Int64))
 getSatValuesFromOutpoint conn txSync lg net outPoint waitSecs = do
-    let str = "SELECT address, value FROM xoken.txid_outputs WHERE txid=? AND output_index=?"
-        qstr = str :: Q.QueryString Q.R (Text, Int32) (Text, Int64)
+    let str = "SELECT address, script_hash, value FROM xoken.txid_outputs WHERE txid=? AND output_index=?"
+        qstr = str :: Q.QueryString Q.R (Text, Int32) (Text, Text, Int64)
         par = Q.defQueryParams Q.One $ (txHashToHex $ outPointHash outPoint, fromIntegral $ outPointIndex outPoint)
     res <- liftIO $ try $ Q.runClient conn (Q.query qstr par)
     case res of
@@ -723,8 +770,8 @@ getSatValuesFromOutpoint conn txSync lg net outPoint waitSecs = do
                             throw TxIDNotFoundException
                         else getSatValuesFromOutpoint conn txSync lg net outPoint waitSecs
                 else do
-                    let (addr, val) = head $ results
-                    return $ (addr, val)
+                    let (addr, scriptHash, val) = head $ results
+                    return $ (addr, scriptHash, val)
         Left (e :: SomeException) -> do
             err lg $ LG.msg $ "Error: getSatValuesFromOutpoint: " ++ show e
             throw e
@@ -826,8 +873,3 @@ handleIfAllegoryTx tx revert = do
         case eres of
             Right () -> return True
             Left (SomeException e) -> throw e
-
-convertToScriptHash :: Network -> String -> Maybe String
-convertToScriptHash net s = do
-    let addr = stringToAddr net (T.pack s)
-    (T.unpack . txHashToHex . TxHash . sha256 . addressToScriptBS) <$> addr

--- a/node/src/Network/Xoken/Node/P2P/Common.hs
+++ b/node/src/Network/Xoken/Node/P2P/Common.hs
@@ -307,3 +307,6 @@ calculateChainWork blks conn = do
         Left (e :: SomeException) -> do
             err lg $ LG.msg $ "Error: xGetBlockHeights: " ++ show e
             throw KeyValueDBLookupException
+
+stripScriptHash :: ((Text, Int32), Int32, (Text, Text, Int64)) -> ((Text, Int32), Int32, (Text, Int64))
+stripScriptHash (op, ii, (addr, scriptHash, satValue)) = (op, ii, (addr, satValue))

--- a/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
@@ -207,23 +207,59 @@ commitEpochScriptHashOutputs conn epoch sh output = do
             err lg $ LG.msg $ "Error: INSERTing into 'ep_script_hash_outputs': " ++ show e
             throw KeyValueDBInsertException
 
+commitEpochScriptHashUnspentOutputs ::
+       (HasLogger m, MonadIO m) => Q.ClientState -> Bool -> Text -> (Text, Int32) -> m ()
+commitEpochScriptHashUnspentOutputs conn epoch sh output = do
+    lg <- getLogger
+    let str = "INSERT INTO xoken.ep_script_hash_unspent_outputs (epoch, script_hash, output) VALUES (?,?,?)"
+        qstr = str :: Q.QueryString Q.W (Bool, Text, (Text, Int32)) ()
+        par = Q.defQueryParams Q.One (epoch, sh, output)
+    res <- liftIO $ try $ Q.runClient conn (Q.write qstr par)
+    case res of
+        Right () -> return ()
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: INSERTing into 'ep_script_hash_unspent_outputs': " ++ show e
+            throw KeyValueDBInsertException
+
+deleteEpochScriptHashUnspentOutputs ::
+       (HasLogger m, MonadIO m) => Q.ClientState -> Bool -> Text -> (Text, Int32) -> m ()
+deleteEpochScriptHashUnspentOutputs conn epoch sh output = do
+    lg <- getLogger
+    let str = "DELETE FROM xoken.ep_script_hash_unspent_outputs WHERE epoch=? AND script_hash=? AND output=?"
+        qstr = str :: Q.QueryString Q.W (Bool, Text, (Text, Int32)) ()
+        par = Q.defQueryParams Q.One (epoch, sh, output)
+    res <- liftIO $ try $ Q.runClient conn (Q.write qstr par)
+    case res of
+        Right () -> return ()
+        Left (e :: SomeException) -> do
+            err lg $ LG.msg $ "Error: DELETE'ing from 'ep_script_hash_unspent_outputs': " ++ show e
+            throw e
+
 insertEpochTxIdOutputs ::
        (HasLogger m, MonadIO m)
     => Q.ClientState
     -> Bool
     -> (Text, Int32)
     -> Text
+    -> Text
     -> Bool
     -> [((Text, Int32), Int32, (Text, Int64))]
     -> Int64
     -> m ()
-insertEpochTxIdOutputs conn epoch (txid, outputIndex) address isRecv other value = do
+insertEpochTxIdOutputs conn epoch (txid, outputIndex) address scriptHash isRecv other value = do
     lg <- getLogger
     let str =
-            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,output_index,address,is_recv,other,value) VALUES (?,?,?,?,?,?,?)"
+            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,output_index,address,script_hash,is_recv,other,value) VALUES (?,?,?,?,?,?,?,?)"
         qstr =
-            str :: Q.QueryString Q.W (Bool, Text, Int32, Text, Bool, [((Text, Int32), Int32, (Text, Int64))], Int64) ()
-        par = Q.defQueryParams Q.One (epoch, txid, outputIndex, address, isRecv, other, value)
+            str :: Q.QueryString Q.W ( Bool
+                                     , Text
+                                     , Int32
+                                     , Text
+                                     , Text
+                                     , Bool
+                                     , [((Text, Int32), Int32, (Text, Int64))]
+                                     , Int64) ()
+        par = Q.defQueryParams Q.One (epoch, txid, outputIndex, address, scriptHash, isRecv, other, value)
     res <- liftIO $ try $ Q.runClient conn $ (Q.write qstr par)
     case res of
         Right () -> return ()
@@ -298,7 +334,12 @@ processUnconfTransaction tx = do
                  return
                      ((txHashToHex $ outPointHash $ prevOutput b, fromIntegral $ outPointIndex $ prevOutput b), j, val))
             inAddrs
-    let ovs = map (\(a, o, i) -> (fromIntegral $ i, (a, fromIntegral $ outValue o))) outAddrs
+    let ovs =
+            map
+                (\(a, o, i) ->
+                     ( fromIntegral $ i
+                     , (a, (txHashToHex $ TxHash $ sha256 (scriptOutput o)), fromIntegral $ outValue o)))
+                outAddrs
     liftIO $
         H.insert
             (txOutputValuesCache bp2pEnv)
@@ -309,19 +350,21 @@ processUnconfTransaction tx = do
         (\(a, o, i) -> do
              let sh = txHashToHex $ TxHash $ sha256 (scriptOutput o)
              let output = (txHashToHex $ txHash tx, i)
-             insertEpochTxIdOutputs conn epoch output a True inputs (fromIntegral $ outValue o)
+             insertEpochTxIdOutputs conn epoch output a sh True (stripScriptHash <$> inputs) (fromIntegral $ outValue o)
              commitEpochScriptHashOutputs conn epoch sh output
+             commitEpochScriptHashUnspentOutputs conn epoch sh output
              return ())
         outAddrs
     mapM_
-        (\((o, i), a) -> do
+        (\((o, i), (a, sh)) -> do
              let prevOutpoint = (txHashToHex $ outPointHash $ prevOutput o, fromIntegral $ outPointIndex $ prevOutput o)
              let output = (txHashToHex $ txHash tx, i)
              let spendInfo = (\ov -> ((txHashToHex $ txHash tx, fromIntegral $ fst ov), i, snd $ ov)) <$> ovs
-             insertEpochTxIdOutputs conn epoch prevOutpoint a False spendInfo 0)
-        (zip inAddrs (map (\x -> fst $ thd3 x) inputs))
+             insertEpochTxIdOutputs conn epoch prevOutpoint a sh False (stripScriptHash <$> spendInfo) 0
+             deleteEpochScriptHashUnspentOutputs conn epoch sh prevOutpoint)
+        (zip inAddrs (map (\x -> (fst3 $ thd3 x, snd3 $ thd3 x)) inputs))
     --
-    let ipSum = foldl (+) 0 $ (\(_, _, (_, val)) -> val) <$> inputs
+    let ipSum = foldl (+) 0 $ (\(_, _, (_, _, val)) -> val) <$> inputs
         opSum = foldl (+) 0 $ (\(_, o, _) -> fromIntegral $ outValue o) <$> outAddrs
         fees = ipSum - opSum
     --
@@ -330,7 +373,11 @@ processUnconfTransaction tx = do
         par =
             Q.defQueryParams
                 Q.One
-                (epoch, txHashToHex $ txHash tx, Blob $ runPutLazy $ putLazyByteString $ S.encodeLazy tx, inputs, fees)
+                ( epoch
+                , txHashToHex $ txHash tx
+                , Blob $ runPutLazy $ putLazyByteString $ S.encodeLazy tx
+                , (stripScriptHash <$> inputs)
+                , fees)
     res <- liftIO $ try $ Q.runClient conn (Q.write qstr par)
     case res of
         Right () -> return ()
@@ -344,10 +391,16 @@ processUnconfTransaction tx = do
         Nothing -> return ()
 
 getSatValuesFromEpochOutpoint ::
-       Q.ClientState -> (MVar (M.Map TxHash EV.Event)) -> Logger -> Network -> OutPoint -> Int -> IO ((Text, Int64))
+       Q.ClientState
+    -> (MVar (M.Map TxHash EV.Event))
+    -> Logger
+    -> Network
+    -> OutPoint
+    -> Int
+    -> IO ((Text, Text, Int64))
 getSatValuesFromEpochOutpoint conn txSync lg net outPoint waitSecs = do
-    let str = "SELECT address, value FROM xoken.ep_txid_outputs WHERE txid=? AND output_index=?"
-        qstr = str :: Q.QueryString Q.R (Text, Int32) (Text, Int64)
+    let str = "SELECT address, script_hash, value FROM xoken.ep_txid_outputs WHERE txid=? AND output_index=?"
+        qstr = str :: Q.QueryString Q.R (Text, Int32) (Text, Text, Int64)
         par = Q.defQueryParams Q.One $ (txHashToHex $ outPointHash outPoint, fromIntegral $ outPointIndex outPoint)
     res <- liftIO $ try $ Q.runClient conn (Q.query qstr par)
     case res of
@@ -374,8 +427,8 @@ getSatValuesFromEpochOutpoint conn txSync lg net outPoint waitSecs = do
                             throw TxIDNotFoundException
                         else getSatValuesFromEpochOutpoint conn txSync lg net outPoint waitSecs
                 else do
-                    let (addr, val) = head $ results
-                    return $ (addr, val)
+                    let (addr, scriptHash, val) = head $ results
+                    return $ (addr, scriptHash, val)
         Left (e :: SomeException) -> do
             err lg $ LG.msg $ "Error: getSatValuesFromEpochOutpoint: " ++ show e
             throw e

--- a/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
+++ b/node/src/Network/Xoken/Node/P2P/UnconfTxSync.hs
@@ -220,35 +220,15 @@ insertEpochTxIdOutputs ::
 insertEpochTxIdOutputs conn epoch (txid, outputIndex) address isRecv other value = do
     lg <- getLogger
     let str =
-            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,output_index,address,is_recv,is_spent,other,value) VALUES (?,?,?,?,?,?,?,?)"
+            "INSERT INTO xoken.ep_txid_outputs (epoch,txid,output_index,address,is_recv,other,value) VALUES (?,?,?,?,?,?,?)"
         qstr =
-            str :: Q.QueryString Q.W ( Bool
-                                     , Text
-                                     , Int32
-                                     , Text
-                                     , Bool
-                                     , Bool
-                                     , [((Text, Int32), Int32, (Text, Int64))]
-                                     , Int64) ()
-        par = Q.defQueryParams Q.One (epoch, txid, outputIndex, address, isRecv, not isRecv, other, value)
+            str :: Q.QueryString Q.W (Bool, Text, Int32, Text, Bool, [((Text, Int32), Int32, (Text, Int64))], Int64) ()
+        par = Q.defQueryParams Q.One (epoch, txid, outputIndex, address, isRecv, other, value)
     res <- liftIO $ try $ Q.runClient conn $ (Q.write qstr par)
     case res of
         Right () -> return ()
         Left (e :: SomeException) -> do
             err lg $ LG.msg $ "Error: INSERTing into ep_txid_outputs: " ++ show e
-            throw KeyValueDBInsertException
-
-setEpochTxIdOutputsSpentFlag :: (HasLogger m, MonadIO m) => Q.ClientState -> (Text, Int32) -> m ()
-setEpochTxIdOutputsSpentFlag conn (txid, outputIndex) = do
-    lg <- getLogger
-    let str = "UPDATE xoken.ep_txid_outputs SET is_spent=? WHERE txid=? AND output_index=? AND is_spent=?"
-        qstr = str :: Q.QueryString Q.W (Bool, Text, Int32, Bool) ()
-        par = Q.defQueryParams Q.One (True, txid, outputIndex, False)
-    res <- liftIO $ try $ Q.runClient conn $ (Q.write qstr par)
-    case res of
-        Right () -> return ()
-        Left (e :: SomeException) -> do
-            err lg $ LG.msg $ "Error: UPDATE'ing ep_txid_outputs: " ++ show e
             throw KeyValueDBInsertException
 
 processUnconfTransaction :: (HasXokenNodeEnv env m, HasLogger m, MonadIO m) => Tx -> m ()
@@ -338,8 +318,7 @@ processUnconfTransaction tx = do
              let prevOutpoint = (txHashToHex $ outPointHash $ prevOutput o, fromIntegral $ outPointIndex $ prevOutput o)
              let output = (txHashToHex $ txHash tx, i)
              let spendInfo = (\ov -> ((txHashToHex $ txHash tx, fromIntegral $ fst ov), i, snd $ ov)) <$> ovs
-             insertEpochTxIdOutputs conn epoch prevOutpoint a False spendInfo 0
-             setEpochTxIdOutputsSpentFlag conn prevOutpoint)
+             insertEpochTxIdOutputs conn epoch prevOutpoint a False spendInfo 0)
         (zip inAddrs (map (\x -> fst $ thd3 x) inputs))
     --
     let ipSum = foldl (+) 0 $ (\(_, _, (_, val)) -> val) <$> inputs

--- a/schema.cql
+++ b/schema.cql
@@ -39,11 +39,19 @@ CREATE TABLE xoken.ep_script_hash_outputs (
     PRIMARY KEY (epoch, script_hash, output)
 ); 
 
+CREATE TABLE xoken.ep_script_hash_unspent_outputs (
+    epoch boolean,
+    script_hash text,
+    output frozen<tuple<text, int>>,
+    PRIMARY KEY (epoch, script_hash, output)
+);
+
 CREATE TABLE xoken.ep_txid_outputs (
     epoch boolean,
     txid text,
     output_index int,
     address text,
+    script_hash text,
     is_recv boolean,
     other set  <frozen<tuple<frozen<tuple<text, int>>, int, frozen<tuple<text, bigint>>>>>,
     value bigint,
@@ -57,10 +65,17 @@ CREATE TABLE xoken.script_hash_outputs (
     PRIMARY KEY (script_hash, nominal_tx_index, output)
 ) WITH CLUSTERING ORDER BY (nominal_tx_index DESC);
 
+CREATE TABLE xoken.script_hash_unspent_outputs (
+    script_hash text,
+    output frozen<tuple<text, int>>,
+    PRIMARY KEY (script_hash, output)
+);
+
 CREATE TABLE xoken.txid_outputs (
     txid text,
     output_index int,
     address text,
+    script_hash text,
     is_recv boolean,
     block_info frozen<tuple<text, int, int>>,
     other set <frozen<tuple<frozen<tuple<text, int>>, int, frozen<tuple<text, bigint>>>>>,

--- a/schema.cql
+++ b/schema.cql
@@ -45,10 +45,9 @@ CREATE TABLE xoken.ep_txid_outputs (
     output_index int,
     address text,
     is_recv boolean,
-    is_spent boolean,
     other set  <frozen<tuple<frozen<tuple<text, int>>, int, frozen<tuple<text, bigint>>>>>,
     value bigint,
-    PRIMARY KEY(epoch, txid, output_index, is_recv, is_spent)
+    PRIMARY KEY(epoch, txid, output_index, is_recv)
  ) WITH CLUSTERING ORDER BY (txid ASC, output_index ASC);
 
 CREATE TABLE xoken.script_hash_outputs (
@@ -63,11 +62,11 @@ CREATE TABLE xoken.txid_outputs (
     output_index int,
     address text,
     is_recv boolean,
-    is_spent boolean,
+    boolean,
     block_info frozen<tuple<text, int, int>>,
     other set <frozen<tuple<frozen<tuple<text, int>>, int, frozen<tuple<text, bigint>>>>>,
     value bigint,
-    PRIMARY KEY(txid, output_index, is_recv, is_spent)
+    PRIMARY KEY(txid, output_index, is_recv)
 ) WITH CLUSTERING ORDER BY (output_index asc);
 
 CREATE TABLE xoken.blocks_by_height (

--- a/schema.cql
+++ b/schema.cql
@@ -62,7 +62,6 @@ CREATE TABLE xoken.txid_outputs (
     output_index int,
     address text,
     is_recv boolean,
-    boolean,
     block_info frozen<tuple<text, int, int>>,
     other set <frozen<tuple<frozen<tuple<text, int>>, int, frozen<tuple<text, bigint>>>>>,
     value bigint,

--- a/schema.cql
+++ b/schema.cql
@@ -45,9 +45,10 @@ CREATE TABLE xoken.ep_txid_outputs (
     output_index int,
     address text,
     is_recv boolean,
+    is_spent boolean,
     other set  <frozen<tuple<frozen<tuple<text, int>>, int, frozen<tuple<text, bigint>>>>>,
     value bigint,
-    PRIMARY KEY(epoch, txid, output_index, is_recv)
+    PRIMARY KEY(epoch, txid, output_index, is_recv, is_spent)
  ) WITH CLUSTERING ORDER BY (txid ASC, output_index ASC);
 
 CREATE TABLE xoken.script_hash_outputs (
@@ -62,10 +63,11 @@ CREATE TABLE xoken.txid_outputs (
     output_index int,
     address text,
     is_recv boolean,
+    is_spent boolean,
     block_info frozen<tuple<text, int, int>>,
     other set <frozen<tuple<frozen<tuple<text, int>>, int, frozen<tuple<text, bigint>>>>>,
     value bigint,
-    PRIMARY KEY(txid, output_index, is_recv)
+    PRIMARY KEY(txid, output_index, is_recv, is_spent)
 ) WITH CLUSTERING ORDER BY (output_index asc);
 
 CREATE TABLE xoken.blocks_by_height (

--- a/schema.cql
+++ b/schema.cql
@@ -36,8 +36,7 @@ CREATE TABLE xoken.ep_script_hash_outputs (
     epoch boolean,
     script_hash text,
     output frozen<tuple<text, int>>,
-    is_recv boolean,
-    PRIMARY KEY (epoch, script_hash, output, is_recv)
+    PRIMARY KEY (epoch, script_hash, output)
 ); 
 
 CREATE TABLE xoken.ep_txid_outputs (
@@ -55,8 +54,7 @@ CREATE TABLE xoken.script_hash_outputs (
     script_hash text,
     nominal_tx_index bigint,
     output frozen<tuple<text, int>>,
-    is_recv boolean,
-    PRIMARY KEY (script_hash, nominal_tx_index, output, is_recv)
+    PRIMARY KEY (script_hash, nominal_tx_index, output)
 ) WITH CLUSTERING ORDER BY (nominal_tx_index DESC);
 
 CREATE TABLE xoken.txid_outputs (


### PR DESCRIPTION
- remove redundant is_recv field from script_hash_outputs schema
    - script_hash_schema no longer has sender/receiver points-of-view (again!)
- use blank string ("") instead of Nothing/null for addresses that fail to decode to avoid overhead from tombstone entries in Cassandra
- add scriptHash to output values cache
- add scriptHash to txid_outputs table
- maintain table of unspent outputs keyed by scriptHash (script_hash_unspent_outputs)
- mirror all the above changes in Epoch tables