### PR TITLE
173827985 get chain headers

### DIFF
--- a/node/app/Main.hs
+++ b/node/app/Main.hs
@@ -377,7 +377,8 @@ defBitcoinP2P nodeCnf = do
     ts <- newMVar M.empty
     tbt <- MS.new $ maxTMTBuilderThreads nodeCnf
     iut <- newTVarIO False
-    return $ BitcoinP2P nodeCnf g bp mv hl st tl ep tc vc (rpf, rpc) mq ts tbt iut
+    udc <- H.new
+    return $ BitcoinP2P nodeCnf g bp mv hl st tl ep tc vc (rpf, rpc) mq ts tbt iut udc
 
 initNexa :: IO ()
 initNexa = do

--- a/node/src/Network/Xoken/Node/AriviService.hs
+++ b/node/src/Network/Xoken/Node/AriviService.hs
@@ -42,7 +42,7 @@ globalHandlerRpc msg = do
     bp2pEnv <- getBitcoinP2P
     let net = bitcoinNetwork $ nodeConfig bp2pEnv
     liftIO $ printf "Decoded resp: %s\n" (show msg)
-    st <- goGetResource msg net [] True
+    st <- goGetResource msg net [] "" True
     return (Just $ st)
 
 globalHandlerPubSub :: (HasService env m) => ServiceTopic -> PubNotifyMessage -> m Status

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -258,6 +258,9 @@ data RPCReqParams'
     | GetUserByUsername
           { guUsername :: String
           }
+    | DeleteUserByUsername
+          { duUsername :: String
+          }
     deriving (Generic, Show, Hashable, Eq, Serialise, ToJSON)
 
 instance FromJSON RPCReqParams' where
@@ -288,7 +291,8 @@ instance FromJSON RPCReqParams' where
          o .: "email" <*>
          o .:? "roles") <|>
         (GetTxOutputSpendStatus <$> o .: "txid" <*> o .: "index") <|>
-        (GetUserByUsername <$> o .: "username") <|>
+        (GetUserByUsername <$> o .: "getUsername") <|>
+        (DeleteUserByUsername <$> o .: "deleteUsername") <|>
         (GetChainHeaders <$> o .:? "startBlockHeight" .!= 1 <*> o .:? "pageSize" .!= 2000)
 
 data RPCResponseBody

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -255,11 +255,8 @@ data RPCReqParams'
           { gtssHash :: String
           , gtssIndex :: Int32
           }
-    | GetUserByUsername
-          { guUsername :: String
-          }
-    | DeleteUserByUsername
-          { duUsername :: String
+    | UserByUsername
+          { uUsername :: String
           }
     | UpdateUserByUsername
           { uuUsername :: String
@@ -295,9 +292,8 @@ instance FromJSON RPCReqParams' where
          o .: "email" <*>
          o .:? "roles") <|>
         (GetTxOutputSpendStatus <$> o .: "txid" <*> o .: "index") <|>
-        (GetUserByUsername <$> o .: "getUsername") <|>
-        (DeleteUserByUsername <$> o .: "deleteUsername") <|>
-        (UpdateUserByUsername <$> o .: "updateUsername" <*> o .: "updateData") <|>
+        (UserByUsername <$> o .: "username") <|>
+        (UpdateUserByUsername <$> o .: "username" <*> o .: "updateData") <|>
         (GetChainHeaders <$> o .:? "startBlockHeight" .!= 1 <*> o .:? "pageSize" .!= 2000)
 
 data RPCResponseBody
@@ -400,7 +396,7 @@ instance ToJSON RPCResponseBody where
     toJSON (RespBlockByHash b) = object ["block" .= b]
     toJSON (RespBlocksByHashes bs) = object ["blocks" .= bs]
     toJSON (RespChainInfo ci) = object ["chainInfo" .= ci]
-    toJSON (RespChainHeaders chs) = object ["chainHeaders" .= chs]
+    toJSON (RespChainHeaders chs) = object ["blockHeaders" .= chs]
     toJSON (RespTxIDsByBlockHash txids) = object ["txids" .= txids]
     toJSON (RespTransactionByTxID tx) = object ["tx" .= tx]
     toJSON (RespTransactionsByTxIDs txs) = object ["txs" .= txs]
@@ -472,7 +468,7 @@ instance ToJSON AddUserResp where
 data User =
     User
         { uUsername :: String
-        , uPassword :: String
+        , uHashedPassword :: String
         , uFirstName :: String
         , uLastName :: String
         , uEmail :: String

--- a/node/src/Network/Xoken/Node/Data.hs
+++ b/node/src/Network/Xoken/Node/Data.hs
@@ -521,15 +521,19 @@ instance ToJSON BlockHeader' where
 
 data ChainHeader =
     ChainHeader
-        { blockHeader :: BlockHeader'
+        { blockHeight :: Int32
+        , blockHash :: String
+        , blockHeader :: BlockHeader'
         , txCount :: Int32
         }
     deriving (Generic, Show, Hashable, Eq, Serialise)
 
 instance ToJSON ChainHeader where
-    toJSON (ChainHeader (BlockHeader' v pb mr ts bb bn) txc) =
+    toJSON (ChainHeader ht hs (BlockHeader' v pb mr ts bb bn) txc) =
         object
-            [ "blockVersion" .= v
+            [ "blockHeight" .= ht
+            , "blockHash" .= hs
+            , "blockVersion" .= v
             , "prevBlock" .= pb
             , "merkleRoot" .= (reverse2 mr)
             , "blockTimestamp" .= ts

--- a/node/src/Network/Xoken/Node/Env.hs
+++ b/node/src/Network/Xoken/Node/Env.hs
@@ -79,6 +79,7 @@ data BitcoinP2P =
         , txSynchronizer :: !(MVar (M.Map TxHash Event))
         , maxTMTBuilderThreadLock :: !(MSem Int)
         , indexUnconfirmedTx :: !(TVar Bool)
+        , userDataCache :: !(HashTable Text (Text, Int32, Int32, UTCTime, [Text])) -- (name, quota, used, expiry time, roles)
         }
 
 class HasBitcoinP2P m where

--- a/node/src/Network/Xoken/Node/HTTP/Handler.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Handler.hs
@@ -107,7 +107,7 @@ getChainInfo = do
             modifyResponse $ setResponseStatus 500 "Internal Server Error"
             writeBS "INTERNAL_SERVER_ERROR"
         Right (Just ci) -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespChainInfo ci
-        Right Nothing -> throwBadRequest
+        Right Nothing -> throwNotFound
 
 getChainHeaders :: Handler App App ()
 getChainHeaders = do
@@ -135,9 +135,7 @@ getBlockByHash = do
             modifyResponse $ setResponseStatus 500 "Internal Server Error"
             writeBS "INTERNAL_SERVER_ERROR"
         Right (Just rec) -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespBlockByHash rec
-        Right Nothing -> do
-            modifyResponse $ setResponseStatus 400 "Bad Request"
-            writeBS "400 error"
+        Right Nothing -> throwNotFound
 
 getBlocksByHash :: Handler App App ()
 getBlocksByHash = do
@@ -164,9 +162,7 @@ getBlockByHeight = do
             modifyResponse $ setResponseStatus 500 "Internal Server Error"
             writeBS "INTERNAL_SERVER_ERROR"
         Right (Just rec) -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespBlockByHeight rec
-        Right Nothing -> do
-            modifyResponse $ setResponseStatus 400 "Bad Request"
-            writeBS "400 error"
+        Right Nothing -> throwNotFound
 
 getBlocksByHeight :: Handler App App ()
 getBlocksByHeight = do
@@ -193,9 +189,7 @@ getRawTxById = do
             modifyResponse $ setResponseStatus 500 "Internal Server Error"
             writeBS "INTERNAL_SERVER_ERROR"
         Right (Just rec) -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespRawTransactionByTxID rec
-        Right Nothing -> do
-            modifyResponse $ setResponseStatus 400 "Bad Request"
-            writeBS "400 error"
+        Right Nothing -> throwNotFound
 
 getRawTxByIds :: Handler App App ()
 getRawTxByIds = do
@@ -232,9 +226,7 @@ getTxById = do
                 Left err -> do
                     modifyResponse $ setResponseStatus 400 "Bad Request"
                     writeBS "400 error"
-        Right Nothing -> do
-            modifyResponse $ setResponseStatus 400 "Bad Request"
-            writeBS "400 error"
+        Right Nothing -> throwNotFound
 
 getTxByIds :: Handler App App ()
 getTxByIds = do
@@ -516,7 +508,8 @@ getUserByUsername = do
         Left (e :: SomeException) -> do
             modifyResponse $ setResponseStatus 500 "Internal Server Error"
             writeBS "INTERNAL_SERVER_ERROR"
-        Right u -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespUser u
+        Right u@(Just us) -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespUser u
+        Right Nothing -> throwNotFound
 
 --- |
 -- Helper functions
@@ -651,3 +644,8 @@ throwBadRequest :: Handler App App ()
 throwBadRequest = do
     modifyResponse $ setResponseStatus 400 "Bad Request"
     writeBS "Bad Request"
+
+throwNotFound :: Handler App App ()
+throwNotFound = do
+    modifyResponse $ setResponseStatus 404 "Not Found"
+    writeBS "Not Found"

--- a/node/src/Network/Xoken/Node/HTTP/Handler.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Handler.hs
@@ -523,6 +523,19 @@ getUserByUsername = do
         Right u@(Just us) -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespUser u
         Right Nothing -> throwNotFound
 
+deleteUserByUsername :: Handler App App ()
+deleteUserByUsername = do
+    uname <- (fmap $ DTE.decodeUtf8) <$> (getParam "username")
+    pretty <- (maybe True (read . DT.unpack . DTE.decodeUtf8)) <$> (getQueryParam "pretty")
+    res <- LE.try $ xDeleteUserByUsername (fromJust uname)
+    case res of
+        Left (e :: SomeException) -> do
+            modifyResponse $ setResponseStatus 500 "Internal Server Error"
+            writeBS "INTERNAL_SERVER_ERROR"
+        Right () -> do
+            modifyResponse $ setResponseStatus 200 "Deleted"
+            writeBS $ "User deleted"
+
 --- |
 -- Helper functions
 withAuth :: Handler App App () -> Handler App App ()

--- a/node/src/Network/Xoken/Node/HTTP/Handler.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Handler.hs
@@ -507,6 +507,17 @@ getPartiallySignedAllegoryTx GetPartiallySignedAllegoryTx {..} = do
             writeBS $ BSL.toStrict $ encodeResp pretty $ RespPartiallySignedAllegoryTx ops
 getPartiallySignedAllegoryTx _ = throwBadRequest
 
+getUserByUsername :: Handler App App ()
+getUserByUsername = do
+    uname <- (fmap $ DTE.decodeUtf8) <$> (getParam "username")
+    pretty <- (maybe True (read . DT.unpack . DTE.decodeUtf8)) <$> (getQueryParam "pretty")
+    res <- LE.try $ xGetUserByUsername (fromJust uname)
+    case res of
+        Left (e :: SomeException) -> do
+            modifyResponse $ setResponseStatus 500 "Internal Server Error"
+            writeBS "INTERNAL_SERVER_ERROR"
+        Right u -> writeBS $ BSL.toStrict $ encodeResp pretty $ RespUser u
+
 --- |
 -- Helper functions
 withAuth :: Handler App App () -> Handler App App ()

--- a/node/src/Network/Xoken/Node/HTTP/Server.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Server.hs
@@ -19,6 +19,7 @@ apiRoutes =
     [ ("/v1/auth", method POST (withReq authClient))
     , ("/v1/user", method POST (withAuthAs "admin" $ withReq addUser))
     , ("/v1/user/:username", method GET (withAuthAs "admin" getUserByUsername))
+    , ("/v1/user/", method GET (withAuth getCurrentUser))
     , ("/v1/chain/info/", method GET (withAuth getChainInfo))
     , ("/v1/chain/headers/", method GET (withAuth getChainHeaders))
     , ("/v1/block/hash/:hash", method GET (withAuth getBlockByHash))

--- a/node/src/Network/Xoken/Node/HTTP/Server.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Server.hs
@@ -17,7 +17,8 @@ appInit env =
 apiRoutes :: [(B.ByteString, Handler App App ())]
 apiRoutes =
     [ ("/v1/auth", method POST (withReq authClient))
-    , ("/v1/add/user", method POST (withAuthAs "admin" $ withReq addUser))
+    , ("/v1/user", method POST (withAuthAs "admin" $ withReq addUser))
+    , ("/v1/user/:username", method GET (withAuthAs "admin" getUserByUsername))
     , ("/v1/chain/info/", method GET (withAuth getChainInfo))
     , ("/v1/chain/headers/", method GET (withAuth getChainHeaders))
     , ("/v1/block/hash/:hash", method GET (withAuth getBlockByHash))

--- a/node/src/Network/Xoken/Node/HTTP/Server.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Server.hs
@@ -19,6 +19,7 @@ apiRoutes =
     [ ("/v1/auth", method POST (withReq authClient))
     , ("/v1/user", method POST (withAuthAs "admin" $ withReq addUser))
     , ("/v1/user/:username", method GET (withAuthAs "admin" getUserByUsername))
+    , ("/v1/user/:username", method DELETE (withAuthAs "admin" deleteUserByUsername))
     , ("/v1/user/", method GET (withAuth getCurrentUser))
     , ("/v1/chain/info/", method GET (withAuth getChainInfo))
     , ("/v1/chain/headers/", method GET (withAuth getChainHeaders))

--- a/node/src/Network/Xoken/Node/HTTP/Server.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Server.hs
@@ -19,6 +19,7 @@ apiRoutes =
     [ ("/v1/auth", method POST (withReq authClient))
     , ("/v1/add/user", method POST (withAuthAs "admin" $ withReq addUser))
     , ("/v1/chain/info/", method GET (withAuth getChainInfo))
+    , ("/v1/chain/headers/", method GET (withAuth getChainHeaders))
     , ("/v1/block/hash/:hash", method GET (withAuth getBlockByHash))
     , ("/v1/block/hashes", method GET (withAuth getBlocksByHash))
     , ("/v1/block/height/:height", method GET (withAuth getBlockByHeight))

--- a/node/src/Network/Xoken/Node/HTTP/Server.hs
+++ b/node/src/Network/Xoken/Node/HTTP/Server.hs
@@ -20,6 +20,7 @@ apiRoutes =
     , ("/v1/user", method POST (withAuthAs "admin" $ withReq addUser))
     , ("/v1/user/:username", method GET (withAuthAs "admin" getUserByUsername))
     , ("/v1/user/:username", method DELETE (withAuthAs "admin" deleteUserByUsername))
+    , ("/v1/user/:username", method PUT (withAuthAs "admin" $ withReq updateUserByUsername))
     , ("/v1/user/", method GET (withAuth getCurrentUser))
     , ("/v1/chain/info/", method GET (withAuth getChainInfo))
     , ("/v1/chain/headers/", method GET (withAuth getChainHeaders))

--- a/node/src/Network/Xoken/Node/P2P/Common.hs
+++ b/node/src/Network/Xoken/Node/P2P/Common.hs
@@ -276,6 +276,7 @@ addNewUser conn uname fname lname email roles api_quota api_expiry_time = do
                         AddUserResp
                             (User
                                  (T.unpack uname)
+                                 ""
                                  (T.unpack fname)
                                  (T.unpack lname)
                                  (T.unpack email)

--- a/node/src/Network/Xoken/Node/XokenService.hs
+++ b/node/src/Network/Xoken/Node/XokenService.hs
@@ -1284,7 +1284,7 @@ xDeleteUserByUsername name = do
                              else return ())
                     cacheList
         Left (e :: SomeException) -> do
-            err lg $ LG.msg $ "Error: DELETE'ing from 'user_permission': " ++ show e
+            err lg $ LG.msg $ "Error: xDeleteUserByUsername: " ++ show e
             throw e
 
 xUpdateUserByUsername :: (HasXokenNodeEnv env m, MonadIO m) => DT.Text -> UpdateUserByUsername' -> m Bool
@@ -1304,7 +1304,7 @@ xUpdateUserByUsername name (UpdateUserByUsername' {..}) = do
                     Q.defQueryParams
                         Q.One
                         ( fromMaybe
-                              (DT.pack uPassword)
+                              (DT.pack uHashedPassword)
                               ((encodeHex . S.encode . sha256 . B64.encode . BC.pack) <$> uuPassword)
                         , DT.pack $ fromMaybe uFirstName uuFirstName
                         , DT.pack $ fromMaybe uLastName uuLastName
@@ -1325,11 +1325,11 @@ xUpdateUserByUsername name (UpdateUserByUsername' {..}) = do
                                    v
                                  , True))
                 Left (e :: SomeException) -> do
-                    err lg $ LG.msg $ "Error: UPDATE'ing 'user_permission': " ++ show e
+                    err lg $ LG.msg $ "Error: xUpdateUserByUsername: " ++ show e
                     throw e
         Right Nothing -> return False
         Left (e :: SomeException) -> do
-            err lg $ LG.msg $ "Error: UPDATE'ing 'user_permission': " ++ show e
+            err lg $ LG.msg $ "Error: xUpdateUserByUsername: " ++ show e
             throw e
 
 xGetUserBySessionKey :: (HasXokenNodeEnv env m, MonadIO m) => DT.Text -> m (Maybe User)
@@ -1566,7 +1566,7 @@ goGetResource msg net roles sessKey pretty = do
                 _____ -> return $ RPCResponse 400 pretty $ Left $ RPCError INVALID_PARAMS Nothing
         "DELETE_USER" -> do
             case methodParams $ rqParams msg of
-                Just (DeleteUserByUsername u) -> do
+                Just (UserByUsername u) -> do
                     if "admin" `elem` roles
                         then do
                             xDeleteUserByUsername (DT.pack u)
@@ -1595,7 +1595,7 @@ goGetResource msg net roles sessKey pretty = do
             return $ RPCResponse 200 pretty $ Right $ Just $ RespUser usr
         "USERNAME->USER" -> do
             case methodParams $ rqParams msg of
-                Just (GetUserByUsername u) -> do
+                Just (UserByUsername u) -> do
                     if "admin" `elem` roles
                         then do
                             usr <- xGetUserByUsername (DT.pack u)


### PR DESCRIPTION
- Added xGetChainHeaders to return [ChainHeader]
- Added Data types for ChainHeader
- Added response handling for chain headers (HTTPS and JsonRPC)
- Added user data cache and updating of api_used for both TLS and HTTP
- getUserData now works for both TLS and HTTP ("USER" or /user/ will return current user details,"USERNAME->USER" or/user/username/ will fetch details by username but will need admin privileges)
- DELETE users for both TLS and HTTP
- PUT for updating users